### PR TITLE
Added support for role based login for Fritz-Boxes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,11 @@
 # Changelog of the check_nwc_health plugin #
 ############################################
 
+2013-11-08
+- added support for role based login for Fritz Boxes (available since 
+  FRITZ!OS 5.50). Use --community for password, --username for username if
+  role based security is switched on.
+	
 2013-11-07 2.6
 - finished bgp-peer-status (focus on as numbers with --name2)
 - admin down with --interface-status can have any level with --mitigation

--- a/plugins-scripts/UPNP/AVM/FritzBox7390.pm
+++ b/plugins-scripts/UPNP/AVM/FritzBox7390.pm
@@ -57,7 +57,11 @@ sub http_get {
     my $challengeresponse = $challenge . '-' . lc(Digest::MD5::md5_hex($input));
     $resp = HTTP::Request->new(POST => $loginurl);
     $resp->content_type("application/x-www-form-urlencoded");
-    $resp->content("response=$challengeresponse");
+    my $login = "response=$challengeresponse";
+    if ($self->opts->username) {
+        $login .= "&username=" . $self->opts->username;
+    }
+    $resp->content($login);
     my $loginresp = $ua->request($resp);
     $content = $loginresp->content();
     $self->{sid} = ($content =~ /<SID>(.*?)<\/SID>/ && $1);


### PR DESCRIPTION
Since FRITZ!OS 5.50 it is possible to use role based security (so you can add a dedicated user "nagios" for monitoring with less rights). 

This pull requests allows to use --username for specifying the user if this mode is used.

Thanks btw for the hot chili sauce, it is really delicious (I tried it yesterday in my train marathon since I had nothing else to eat ;-) BTW, it is really hot ;-D
