### PR TITLE
interpret Cisco powersupply warning state as warning

### DIFF
--- a/plugins-scripts/Classes/Cisco/CISCOENVMONMIB/Component/PowersupplySubsystem.pm
+++ b/plugins-scripts/Classes/Cisco/CISCOENVMONMIB/Component/PowersupplySubsystem.pm
@@ -21,6 +21,8 @@ sub check {
       $self->{ciscoEnvMonSupplyStatusDescr},
       $self->{ciscoEnvMonSupplyState});
   if ($self->{ciscoEnvMonSupplyState} eq 'notPresent') {
+  } elsif ($self->{ciscoEnvMonSupplyState} eq 'warning') {
+    $self->add_warning();
   } elsif ($self->{ciscoEnvMonSupplyState} ne 'normal') {
     $self->add_critical();
   }


### PR DESCRIPTION
Before this change a warning results in a critical plugin state.
