### PR TITLE
Several changes to the check-config mode for Cisco IOS systems.

### DIFF
--- a/plugins-scripts/Classes/Cisco/IOS/Component/ConfigSubsystem.pm
+++ b/plugins-scripts/Classes/Cisco/IOS/Component/ConfigSubsystem.pm
@@ -1,6 +1,7 @@
 package Classes::Cisco::IOS::Component::ConfigSubsystem;
 our @ISA = qw(GLPlugin::SNMP::Item);
 use strict;
+use constant { OK => 0, WARNING => 1, CRITICAL => 2, UNKNOWN => 3 };
 
 sub init {
   my $self = shift;
@@ -19,46 +20,54 @@ sub init {
 sub check {
   my $self = shift;
   my $info;
+  my $runningChangedMarginAfterReload = 300;
   $self->add_info('checking config');
   if ($self->check_messages()) {
     return;
   }
+
+  # Set default thresholds: Warning 1 hour, Critical 24 hours
+  $self->set_thresholds(warning => 3600, critical => 3600*24);
+
+  # How much is ccmHistoryRunningLastChanged ahead of ccmHistoryStartupLastChanged
+  # Note: the saved config could still be identical to the running config.
+
   # ccmHistoryRunningLastChanged
   # ccmHistoryRunningLastSaved - saving is ANY write (local/remote storage, terminal)
   # ccmHistoryStartupLastChanged 
-  $self->set_thresholds(warning => 3600, critical => 3600*24);
+  my $runningUnchangedDuration = time - $self->{ccmHistoryRunningLastChanged};
+  my $startupUnchangedDuration = time - $self->{ccmHistoryStartupLastChanged};
 
-  # how much is ccmHistoryRunningLastChanged ahead of ccmHistoryRunningLastSaved
-  # the current running config is definitively lost in case of an outage
-  my $unsaved_since =
-      $self->{ccmHistoryRunningLastChanged} > $self->{ccmHistoryRunningLastSaved} ?
-      time - $self->{ccmHistoryRunningLastChanged} : 0;
+  # If running config has been changed after the startup config
+  if ($runningUnchangedDuration < $startupUnchangedDuration) {
+    # After a reload the running config is reported to be ahead of the startup config by a few seconds to possibly
+    # a few minutes, while neither has been changed. Therefor a reload-margin is used.
+    # If running config is reported to have changed within the (5 minute) margin since the last reload
+    if (($runningUnchangedDuration + $runningChangedMarginAfterReload) > $self->uptime()) {
+      $self->add_ok(sprintf("running config has not changed since reload (using a %d second margin)",
+          $runningChangedMarginAfterReload));
+    } else {
+      # Running config is unsaved since $runningUnchangedDuration
+      my $errorlevel = $self->check_thresholds($runningUnchangedDuration);
 
-  # how much is ccmHistoryRunningLastSaved ahead of ccmHistoryStartupLastChanged
-  # the running config could have been saved for backup purposes.
-  # the saved config can still be identical to the saved running config
-  # if there are regular backups of the running config and no one messes
-  # with the latter without flushing it to the startup config, then i recommend
-  # to use --mitigation ok. this can be in an environment, where there is
-  # a specific day of the week reserved for maintenance and admins are forced
-  # to save their modifications to the startup-config.
-  my $unsynced_since = 
-      $self->{ccmHistoryRunningLastSaved} > $self->{ccmHistoryStartupLastChanged} ? 
-      time - $self->{ccmHistoryRunningLastSaved} : 0;
-  if ($unsaved_since) {
-    $self->add_info(sprintf "running config is modified and unsaved since %d minutes. your changes my be lost in case of a reboot",
-        $unsaved_since / 60);
+      if ($errorlevel != OK && defined $self->opts->mitigation()) {
+        $errorlevel = $self->opts->mitigation();
+      }
+
+      $self->add_info(sprintf "running config is ahead of startup config since %d minutes. changes will be lost in case of a reboot",
+          $runningUnchangedDuration / 60);
+      $self->add_message($errorlevel);
+    }
   } else {
-    $self->add_info("saved config is up to date");
+    $self->add_ok("saved config is up to date");
   }
-  $self->add_message($self->check_thresholds($unsaved_since));
-  if ($unsynced_since) {
-    my $errorlevel = defined $self->opts->mitigation() ?
-        $self->opts->mitigation() :
-        $self->check_thresholds($unsynced_since);
-    $self->add_info(sprintf "saved running config is ahead of startup config since %d minutes. device will boot with a config different from the one which was last saved",
-        $unsynced_since / 60);
-    $self->add_message($self->check_thresholds($unsaved_since));
+}
+
+sub dump {
+  my $self = shift;
+  printf "[CONFIG]\n";
+  foreach (qw(ccmHistoryRunningLastChanged ccmHistoryRunningLastSaved ccmHistoryStartupLastChanged)) {
+    printf "%s: %s (%s)\n", $_, $self->{$_}, scalar localtime $self->{$_};
   }
 }
 


### PR DESCRIPTION
I didn't find the check usefull as it was. When doing a simple "sh run" on the device to check the current config (or doing automated remote backups,) the check started to spit out warnings, etc. Now it only does so when you've entered config mode. This still doesn't check if the running config is truely different from the startup config, but that cannot be done through SNMP for as far as I know.
Changes:

* Modified config check to only take the running-config-changed and the startup-config-changed
values into account. (The running-config-saved value is not usefull for this check)
* Added a time-margin after a reload (5 minutes seems reasonable) wherein the running-config-changed time
may be ahead of the startup-config-changed time. After a reload, the device may report a
running-config-changed time of up to 5 minutes later than the startup-config-changed time when
in fact nothing has changed.
* Fixed mitigation; this parameter had no effect.