### PR TITLE
Add mode hardware-health, cpu-load, memory-usage for Clavister

### DIFF
--- a/plugins-scripts/Classes/Clavister.pm
+++ b/plugins-scripts/Classes/Clavister.pm
@@ -1,0 +1,19 @@
+package Classes::Clavister;
+our @ISA = qw(Classes::Device);
+use strict;
+
+use constant trees => (
+    '1.3.6.1.4.1.5089', # CLAVISTER-MIB
+);
+
+sub init {
+  my $self = shift;
+  if ($self->{productname} =~ /Clavister/i) {
+    bless $self, 'Classes::Clavister::Firewall1';
+    $self->debug('using Classes::Clavister::Firewall1');
+  }
+  if (ref($self) ne "Classes::Clavister") {
+    $self->init();
+  }
+}
+

--- a/plugins-scripts/Classes/Clavister/Firewall1.pm
+++ b/plugins-scripts/Classes/Clavister/Firewall1.pm
@@ -1,0 +1,17 @@
+package Classes::Clavister::Firewall1;
+our @ISA = qw(Classes::Clavister);
+use strict;
+
+sub init {
+  my $self = shift;
+  if ($self->mode =~ /device::hardware::health/) {
+    $self->analyze_and_check_environmental_subsystem("Classes::Clavister::Firewall1::Component::EnvironmentalSubsystem");
+  } elsif ($self->mode =~ /device::hardware::load/) {
+    $self->analyze_and_check_cpu_subsystem("Classes::Clavister::Firewall1::Component::CpuSubsystem");
+  } elsif ($self->mode =~ /device::hardware::memory/) {
+    $self->analyze_and_check_mem_subsystem("Classes::Clavister::Firewall1::Component::MemSubsystem");
+  } else {
+    $self->no_such_mode();
+  }
+}
+

--- a/plugins-scripts/Classes/Clavister/Firewall1/Component/CpuSubsystem.pm
+++ b/plugins-scripts/Classes/Clavister/Firewall1/Component/CpuSubsystem.pm
@@ -1,0 +1,23 @@
+package Classes::Clavister::Firewall1::Component::CpuSubsystem;
+our @ISA = qw(GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my $self = shift;
+  $self->get_snmp_objects('CLAVISTER-MIB', (qw(
+      clvSysCpuLoad)));
+}
+
+sub check {
+  my $self = shift;
+  $self->add_info('checking cpus');
+  $self->add_info(sprintf 'cpu usage is %.2f%%', $self->{clvSysCpuLoad});
+  $self->set_thresholds(warning => 80, critical => 90);
+  $self->add_message($self->check_thresholds($self->{clvSysCpuLoad}));
+  $self->add_perfdata(
+      label => 'cpu_usage',
+      value => $self->{clvSysCpuLoad},
+      uom => '%',
+  );
+}
+

--- a/plugins-scripts/Classes/Clavister/Firewall1/Component/EnvironmentalSubsystem.pm
+++ b/plugins-scripts/Classes/Clavister/Firewall1/Component/EnvironmentalSubsystem.pm
@@ -1,0 +1,47 @@
+package Classes::Clavister::Firewall1::Component::EnvironmentalSubsystem;
+our @ISA = qw(GLPlugin::SNMP::Item);
+use strict;
+use Data::Dumper;
+
+sub init {
+  my $self = shift;
+  $self->get_snmp_tables('CLAVISTER-MIB', [
+      ['sensor', 'clvHWSensorEntry', 'Classes::Clavister::Firewall1::Component::HWSensor'],
+  ]);
+}
+
+sub check {
+  my $self = shift;
+  foreach (@{$self->{sensor}}) {
+    $_->check();
+  }
+}
+
+
+package Classes::Clavister::Firewall1::Component::HWSensor;
+our @ISA = qw(GLPlugin::SNMP::TableItem);
+use strict;
+
+sub check {
+  my $self = shift;
+  if ($self->{clvHWSensorName} =~ /Fan/i) {
+    $self->add_info(sprintf '%s is running (%d %s)', 
+        $self->{clvHWSensorName}, $self->{clvHWSensorValue}, $self->{clvHWSensorUnit});
+    $self->set_thresholds(warning => "6000:7500", critical => "1000:10000");
+    $self->add_message($self->check_thresholds($self->{clvHWSensorValue}));
+    $self->add_perfdata(
+        label => $self->{clvHWSensorName}.'_rpm',
+        value => $self->{clvHWSensorValue},
+    );
+  } elsif ($self->{clvHWSensorName} =~ /Temp/i) {
+    $self->add_info(sprintf '%s is running (%d %s)',
+        $self->{clvHWSensorName}, $self->{clvHWSensorValue}, $self->{clvHWSensorUnit});
+    $self->set_thresholds(warning => 60, critical => 70);
+    $self->add_message($self->check_thresholds($self->{clvHWSensorValue}));
+    $self->add_perfdata(
+        label => $self->{clvHWSensorName}.'_'.$self->{clvHWSensorUnit},
+        value => $self->{clvHWSensorValue},
+    );
+  }
+}
+

--- a/plugins-scripts/Classes/Clavister/Firewall1/Component/MemSubsystem.pm
+++ b/plugins-scripts/Classes/Clavister/Firewall1/Component/MemSubsystem.pm
@@ -1,0 +1,22 @@
+package Classes::Clavister::Firewall1::Component::MemSubsystem;
+our @ISA = qw(GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my $self = shift;
+  $self->get_snmp_objects('CLAVISTER-MIB', (qw(
+      clvSysMemUsage)));
+}
+
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf 'memory usage is %.2f%%', $self->{clvSysMemUsage});
+  $self->set_thresholds(warning => 80, critical => 90);
+  $self->add_message($self->check_thresholds($self->{clvSysMemUsage}));
+  $self->add_perfdata(
+      label => 'memory_usage',
+      value => $self->{clvSysMemUsage},
+      uom => '%',
+  );
+}
+

--- a/plugins-scripts/Classes/Device.pm
+++ b/plugins-scripts/Classes/Device.pm
@@ -25,6 +25,7 @@ sub classify {
       $self->{productname} = 'procurve' if $self->opts->servertype eq 'procurve';
       $self->{productname} = 'bluecoat' if $self->opts->servertype eq 'bluecoat';
       $self->{productname} = 'checkpoint' if $self->opts->servertype eq 'checkpoint';
+      $self->{productname} = 'clavister' if $self->opts->servertype eq 'clavister';
       $self->{productname} = 'ifmib' if $self->opts->servertype eq 'ifmib';
     }
     if (! $self->check_messages()) {
@@ -110,6 +111,9 @@ sub classify {
       } elsif ($self->{productname} =~ /(cpx86_64)|(Check\s*Point)|(Linux.*\dcp )/i) {
         bless $self, 'Classes::CheckPoint';
         $self->debug('using Classes::CheckPoint');
+      } elsif ($self->{productname} =~ /Clavister/i) {
+        bless $self, 'Classes::Clavister';
+        $self->debug('using Classes::Clavister');
       } elsif ($self->{productname} =~ /Blue\s*Coat/i) {
         bless $self, 'Classes::Bluecoat';
         $self->debug('using Classes::Bluecoat');

--- a/plugins-scripts/Classes/MibsAndOids.pm
+++ b/plugins-scripts/Classes/MibsAndOids.pm
@@ -4362,6 +4362,17 @@ $GLPlugin::SNMP::mibs_and_oids = {
           2 => 'unknown',
       },
   },
+  'CLAVISTER-MIB' => {
+      'clvSystem' => '1.3.6.1.4.1.5089.1.2.1',
+      'clvSysCpuLoad' => '1.3.6.1.4.1.5089.1.2.1.1.0',
+      'clvHWSensorTable' => '1.3.6.1.4.1.5089.1.2.1.11',
+      'clvHWSensorEntry' => '1.3.6.1.4.1.5089.1.2.1.11.1',
+      'clvHWSensorIndex' => '1.3.6.1.4.1.5089.1.2.1.11.1.1',
+      'clvHWSensorName' => '1.3.6.1.4.1.5089.1.2.1.11.1.2',
+      'clvHWSensorValue' => '1.3.6.1.4.1.5089.1.2.1.11.1.3',
+      'clvHWSensorUnit' => '1.3.6.1.4.1.5089.1.2.1.11.1.4',
+      'clvSysMemUsage' => '1.3.6.1.4.1.5089.1.2.1.12.0',
+  },
   'NETSCREEN-RESOURCE-MIB' => {
       nsResCpuAvg => '1.3.6.1.4.1.3224.16.1.1.0',
       nsResCpuLast15Min => '1.3.6.1.4.1.3224.16.1.4.0',

--- a/plugins-scripts/Makefile.am
+++ b/plugins-scripts/Makefile.am
@@ -137,6 +137,11 @@ EXTRA_MODULES=\
   Classes/CheckPoint/Firewall1/Component/MemSubsystem.pm \
   Classes/CheckPoint/Firewall1.pm \
   Classes/CheckPoint.pm \
+  Classes/Clavister/Firewall1/Component/EnvironmentalSubsystem.pm \
+  Classes/Clavister/Firewall1/Component/CpuSubsystem.pm \
+  Classes/Clavister/Firewall1/Component/MemSubsystem.pm \
+  Classes/Clavister/Firewall1.pm \
+  Classes/Clavister.pm \
   Classes/SGOS/Component/MemSubsystem.pm \
   Classes/SGOS/Component/CpuSubsystem.pm \
   Classes/SGOS/Component/EnvironmentalSubsystem.pm \


### PR DESCRIPTION
Hello,

I have added mode hardware-health, cpu-load, memory-usage for Clavister Firewall based on the existing CheckPoint Firewall implementation.

Best Regards,
 Dirk
