### PR TITLE
configure.ac: Support --disable-maintainer-mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,7 @@ AC_REVISION ($Revision: 1.150 $)
 AC_PREREQ(2.58)
 AC_INIT(check_nwc_health,3.4.4.1)
 AM_INIT_AUTOMAKE([1.9 tar-pax])
+AM_MAINTAINER_MODE([enable])
 AC_CANONICAL_HOST
 
 RELEASE=1


### PR DESCRIPTION
This allows you to choose whether the so called "rebuild rules" should be
enabled or disabled.  With AM_MAINTAINER_MODE([enable]), they are
enabled by default, otherwise they are disabled by default.  In the
latter case, if you have AM_MAINTAINER_MODE in configure.ac, and run
`./configure && make', then make will *never* attempt to rebuild
configure, Makefile.ins, Lex or Yacc outputs, etc.  I.e., this
disables build rules for files that are usually distributed and that
users should normally not have to update.

The user can override the default setting by passing either
`--enable-maintainer-mode' or `--disable-maintainer-mode' to
configure.

People use AM_MAINTAINER_MODE either because they do not want their
users (or themselves) annoyed by timestamps lossage (see CVS), or
because they simply can't stand the rebuild rules and prefer running
maintainer tools explicitly.

[ https://www.gnu.org/software/automake/manual/automake.html ]