### PR TITLE
fix and adjust perfdata labels for Ironport check-licenses mode

### DIFF
--- a/plugins-scripts/Classes/Cisco/AsyncOS/Component/KeySubsystem.pm
+++ b/plugins-scripts/Classes/Cisco/AsyncOS/Component/KeySubsystem.pm
@@ -29,8 +29,11 @@ sub check {
     $self->set_thresholds(warning => '14:', critical => '7:');
     $self->add_message($self->check_thresholds($self->{keyDaysUntilExpire}));
   }
+  $self->{keyDescription} =~ s/Ironport//gi;
+  $self->{keyDescription} =~ s/^ //;
+  $self->{keyDescription} =~ s/ /_/g;
   $self->add_perfdata(
-      label => sprintf('lifetime_%s', $self->{keyDaysUntilExpire}),
+      label => sprintf('lifetime_%s', $self->{keyDescription}),
       value => $self->{keyDaysUntilExpire},
       thresholds => $self->{keyIsPerpetual} eq 'true' ? 0 : 1,
   );


### PR DESCRIPTION
For Ironport check-licenses mode I changed the perfdata labels from keyDaysUntilExpire to keyDescription. Otherwise there would be a new data source label each day.
I also changed the keyDescription for perfdata usage. IMHO the resulting label would be too long.