### PR TITLE
Fix bug for CheckPoint/IPSO devices

### DIFF
--- a/plugins-scripts/Classes/Device.pm
+++ b/plugins-scripts/Classes/Device.pm
@@ -140,9 +140,9 @@ sub classify {
       } elsif ($self->{productname} =~ /Procurve/i) {
         bless $self, 'Classes::HP';
         $self->debug('using Classes::HP');
-      } elsif ($self->{productname} =~ /(cpx86_64)|(Check\s*Point)|(Linux.*\dcp )/i) {
-        bless $self, 'Classes::CheckPoint';
-        $self->debug('using Classes::CheckPoint');
+      } elsif ($self->{productname} =~ /((cpx86_64)|(Check\s*Point)|(IPSO)|(Linux.*\dcp) )/i) {
+        bless $self, 'Classes::CheckPoint::Firewall1';
+        $self->debug('using Classes::CheckPoint::Firewall1');
       } elsif ($self->{productname} =~ /Clavister/i) {
         bless $self, 'Classes::Clavister';
         $self->debug('using Classes::Clavister');


### PR DESCRIPTION
With this patch, CheckPoint devices work again. 

Before the patch:

    ./check_nwc_health --hostname target --community public --mode cpu-load -v -v 
    I am a IPSO fwname 6.2-GA039 releng 1 04.14.2010-225515 i386
    OK - 

Even servertype didn't work:

    ./check_nwc_health --hostname target --community public --mode cpu-load --servertype CheckPoint -v -v
    I am a CheckPoint
    OK - 

After applying the patch:

    ./check_nwc_health --hostname target --community public --mode cpu-load -v -v 
    I am a IPSO fwname 6.2-GA039 releng 1 04.14.2010-225515 i386
    [CPUSUBSYSTEM]
    procQueue: 1
    procUsage: 66
    info: cpu usage is 66.00%
    
    OK - cpu usage is 66.00%
    checking cpus
    cpu usage is 66.00% | 'cpu_usage'=66%;80;90;0;100 'cpu_queue_length'=1;80;90;;


    