### PR TITLE
Chomp potential newline from Checkpoint haState value

### DIFF
--- a/plugins-scripts/Classes/CheckPoint/Firewall1/Component/HaSubsystem.pm
+++ b/plugins-scripts/Classes/CheckPoint/Firewall1/Component/HaSubsystem.pm
@@ -16,6 +16,7 @@ sub init {
 
 sub check {
   my $self = shift;
+  chomp($self->{haState});
   $self->add_info('checking ha');
   $self->add_info(sprintf 'ha %sstarted, role is %s, status is %s', 
       $self->{haStarted} eq 'yes' ? '' : 'not ', 


### PR DESCRIPTION
On a CheckPoint Firewall the SNMP value for haState contained a newline character (bug in Checkpoint?). This newline is not expected and breaks the "ha-role" check:

    ./check_nwc_health --hostname 1.2.3.4 --community public --mode ha-role  -v -v
    I am a Linux fwz005 2.6.18-92cp #1 SMP Wed Apr 8 15:46:38 IDT 2015 i686
    [HASUBSYSTEM]
    haStarted: yes
    haStatShort: OK
    haState: Active
    
    info: ha started, role is Active
    , status is OK
    
    WARNING - ha started, role is Active
    , status is OK, expected role active
    checking ha
    ha started, role is Active
    , status is OK

This can be verified in the snmp output:

    $ snmpwalk -v 2c -c public 1.2.3.4 1.3.6.1.4.1.2620.1.5.6.0
    iso.3.6.1.4.1.2620.1.5.6.0 = STRING: "Active
    "

On an older CheckPoint IPSO device, there is no newline character in the value (and its written in lower case, too, but that doesnt matter):

    $ snmpwalk -v 2c -c public 1.2.2.6 1.3.6.1.4.1.2620.1.5.6.0
    iso.3.6.1.4.1.2620.1.5.6.0 = STRING: "active"

A chomp on $self->{haState} fixes this:

    ./check_nwc_health --hostname 1.2.3.4 --community public --mode ha-role --role Active -v -v
    I am a Linux fwz005 2.6.18-92cp #1 SMP Wed Apr 8 15:46:38 IDT 2015 i686
    [HASUBSYSTEM]
    haStarted: yes
    haStatShort: OK
    haState: Active
    info: ha started, role is Active, status is OK
    
    OK - ha started, role is Active, status is OK
    checking ha
    ha started, role is Active, status is OK

Also tested with the older CheckPoint IPSO; works, too.