### PR TITLE
Use of uninitialized value $1 in hash element

### DIFF
--- a/lib/Monitoring/GLPlugin/SNMP.pm
+++ b/lib/Monitoring/GLPlugin/SNMP.pm
@@ -755,7 +755,7 @@ sub init {
     }
     my $toplevels = {};
     map {
-        /^(1\.3\.6\.1\.(\d+)\.(\d+)\.\d+\.\d+)\./; $toplevels->{$1} = 1; 
+        /^(1\.3\.6\.1\.(\d+)\.(\d+)\.\d+\.\d+)\./; $toplevels->{$1} = 1 if (defined $1);
     } keys %{$unknowns};
     foreach (sort {$a cmp $b} keys %{$toplevels}) {
       push(@outputlist, ["<unknown>", $_]);


### PR DESCRIPTION
When executing "supportedmibs" using a provided snmpwalk file.

    Use of uninitialized value $1 in hash element at ./check_nwc_health line 2955.

The problematic line is:

    map {
        /^(1\.3\.6\.1\.(\d+)\.(\d+)\.\d+\.\d+)\./; $toplevels->{$1} = 1;
    } keys %{$unknowns};