### PR TITLE
Fix hex string parsing of snmpwalk files and CISCO-ALARM-MIB

### DIFF
--- a/lib/Monitoring/GLPlugin/SNMP.pm
+++ b/lib/Monitoring/GLPlugin/SNMP.pm
@@ -830,7 +830,7 @@ sub check_snmp_and_model {
           my $k = $1;
           my $h = $2;
           $h =~ s/\s+//g;
-          $response->{$h} = pack('H*', $h);
+          $response->{$k} = pack('H*', $h);
         } elsif (/^([\d\.]+) = \w+: (\-*\d+)\s*$/) {
           $response->{$1} = $2;
         } elsif (/^([\d\.]+) = \w+: "(.*?)"/) {

--- a/lib/Monitoring/GLPlugin/SNMP.pm
+++ b/lib/Monitoring/GLPlugin/SNMP.pm
@@ -827,8 +827,10 @@ sub check_snmp_and_model {
         } elsif (/^([\d\.]+) = Network Address: (.*)/) {
           $response->{$1} = $2;
         } elsif (/^([\d\.]+) = Hex-STRING: (.*)/) {
-          $response->{$1} = "0x".$2;
-          $response->{$1} =~ s/\s+$//;
+          my $k = $1;
+          my $h = $2;
+          $h =~ s/\s+//g;
+          $response->{$h} = pack('H*', $h);
         } elsif (/^([\d\.]+) = \w+: (\-*\d+)\s*$/) {
           $response->{$1} = $2;
         } elsif (/^([\d\.]+) = \w+: "(.*?)"/) {

--- a/plugins-scripts/Classes/Cisco/CISCOENTITYALARMMIB/Component/AlarmSubsystem.pm
+++ b/plugins-scripts/Classes/Cisco/CISCOENTITYALARMMIB/Component/AlarmSubsystem.pm
@@ -64,7 +64,7 @@ sub finish {
   $self->{ceAlarmTypes} = [];
   if ($self->{ceAlarmList}) {
     my $index = 0;
-    foreach my $octet (split(/\s+/, $self->{ceAlarmList})) {
+    foreach my $octet (unpack('H2', $self->{ceAlarmList})) {
       my $hexoctet = hex($octet) & 0xff;
       if ($hexoctet) {
         my $base = 8 * $index;


### PR DESCRIPTION
Ths change fixes the way how the snmpwalk file transforms a Hex-String value. I don't know if this change affects other parts of the big script. But as it only effects the snmpwalk file parsing in the first place I don't see it mission critical. but it's possible that other checks now have problems when working with Hex-String data.

So please check with care.