### PR TITLE
Hsrp allow multiple roles

### DIFF
--- a/plugins-scripts/Classes/HSRP/Component/HSRPSubsystem.pm
+++ b/plugins-scripts/Classes/HSRP/Component/HSRPSubsystem.pm
@@ -57,13 +57,21 @@ sub finish {
 sub check {
   my $self = shift;
   if ($self->mode =~ /device::hsrp::state/) {
-    $self->add_info(sprintf 'hsrp group %s (interface %s) state is %s (active router is %s, standby router is %s',
+    $self->add_info(sprintf 'hsrp group %s (interface %s) state is %s (active router is %s, standby router is %s)',
         $self->{cHsrpGrpNumber}, $self->{ifIndex},
         $self->{cHsrpGrpStandbyState},
         $self->{cHsrpGrpActiveRouter}, $self->{cHsrpGrpStandbyRouter});
     my @roles = split ',', $self->opts->role();
     if (grep $_ eq $self->{cHsrpGrpStandbyState}, @roles) {
+      if ($self->{cHsrpGrpStandbyRouter} eq '0.0.0.0') {
+        $self->add_message(
+          defined $self->opts->mitigation() ? $self->opts->mitigation() : 1,
+          sprintf 'standby hsrp router missing in group %s (interface %s)',
+          $self->{cHsrpGrpNumber}, $self->{ifIndex}
+        );
+      } else {
         $self->add_ok();
+      }
     } else {
       $self->add_critical(
           sprintf 'state in group %s (interface %s) is %s instead of %s',

--- a/plugins-scripts/Classes/HSRP/Component/HSRPSubsystem.pm
+++ b/plugins-scripts/Classes/HSRP/Component/HSRPSubsystem.pm
@@ -61,7 +61,8 @@ sub check {
         $self->{cHsrpGrpNumber}, $self->{ifIndex},
         $self->{cHsrpGrpStandbyState},
         $self->{cHsrpGrpActiveRouter}, $self->{cHsrpGrpStandbyRouter});
-    if ($self->opts->role() eq $self->{cHsrpGrpStandbyState}) {
+    my @roles = split ',', $self->opts->role();
+    if (grep $_ eq $self->{cHsrpGrpStandbyState}, @roles) {
         $self->add_ok();
     } else {
       $self->add_critical(


### PR DESCRIPTION
This change allows the admin to accept multiple rows as role

    --role active,standby

As long as the router is in one of those states the monitor will be ok. This can be helpful in big environments where the role is splitted over multiple devices for load sharing.

A second check has been added that issues a warning when the active or standby router IP address matches `0.0.0.0` (aka partner missing). This warning can be overruled using `--mitigation` for cases where there's hsrp configured but no partner has been added yet.