### PR TITLE
Fixes: lsmpi_io mempool is always at 99% on ASR1000

### DIFF
--- a/plugins-scripts/Classes/Cisco/CISCOENHANCEDMEMPOOLMIB/Component/MemSubsystem.pm
+++ b/plugins-scripts/Classes/Cisco/CISCOENHANCEDMEMPOOLMIB/Component/MemSubsystem.pm
@@ -31,7 +31,7 @@ sub check {
   $self->add_info(sprintf 'mempool %s usage is %.2f%%',
       $self->{name}, $self->{usage});
   if ($self->{name} =~ /^lsmpi_io/ &&
-      $self->get_snmp_object('MIB-2-MIB', 'sysDescr', 0) =~ /IOS.*XE/i) {
+      $self->get_snmp_object('MIB-2-MIB', 'sysDescr', 0) =~ /IOS.*(XE|ASR1000)/i) {
     # https://supportforums.cisco.com/docs/DOC-16425
     $self->force_thresholds(
         metric => $self->{name}.'_usage',


### PR DESCRIPTION
Some routers identify themself as ASR1000 instead of IOS-XE which is
ignored by the current expressions.

This results in errors like "mempool lsmpi_io_7000 usage is 99.98%"