### PR TITLE
filter interface alias using --name3

### DIFF
--- a/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
+++ b/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
@@ -271,6 +271,7 @@ sub get_interface_indices {
   foreach my $ifIndex (keys %{$self->{interface_cache}}) {
     my $ifDescr = $self->{interface_cache}->{$ifIndex}->{ifDescr};
     my $ifAlias = $self->{interface_cache}->{$ifIndex}->{ifAlias} || '________';
+    # Check ifDescr (using --name)
     if ($self->opts->name) {
       if ($self->opts->regexp) {
         my $pattern = $self->opts->name;
@@ -288,6 +289,19 @@ sub get_interface_indices {
           }
         }
       }
+    # Check ifAlias (using --name3)
+    } elsif ($self->opts->name3} {
+      if ($self->opts->regexp) {
+        my $pattern = $self->opts->name3;
+        if ($ifAlias =~ /$pattern/i) {
+          push(@indices, [$ifIndex]);
+        }
+      } else {
+        if (lc $ifAlias eq lc $self->opts->name3) {
+          push(@indices, [$ifIndex]);
+        }
+      }
+    # take all interfaces
     } else {
       push(@indices, [$ifIndex]);
     }


### PR DESCRIPTION
Filter the interface list using the ifAlias attribute

Example Usage:
Report Traffic usage for all interfaces contains the keyword "customer" in the interface description

    --mode interface-usage --name3 customer --regexp

This could help selecting the correct interfaces on large router/switch environments where the ports used differs on multiple devices