### PR TITLE
set cpu usage thresholds for dedicated cpus

### DIFF
--- a/plugins-scripts/Classes/HOSTRESOURCESMIB/Component/CpuSubsystem.pm
+++ b/plugins-scripts/Classes/HOSTRESOURCESMIB/Component/CpuSubsystem.pm
@@ -22,8 +22,12 @@ sub check {
   $self->add_info(sprintf 'cpu %s is %.2f%%',
       $self->{hrProcessorIndex},
       $self->{hrProcessorLoad});
-  $self->set_thresholds(warning => '80', critical => '90');
-  $self->add_message($self->check_thresholds($self->{hrProcessorLoad}));
+  $self->set_thresholds(
+      metric => sprintf('cpu_%s_usage', $self->{hrProcessorIndex}),
+      warning => '80', critical => '90');
+  $self->add_message($self->check_thresholds(
+      metric => sprintf('cpu_%s_usage', $self->{hrProcessorIndex}),
+      value => $self->{hrProcessorLoad}));
   $self->add_perfdata(
       label => sprintf('cpu_%s_usage', $self->{hrProcessorIndex}),
       value => $self->{hrProcessorLoad},


### PR DESCRIPTION
We found Firewalls that reserve dedicated CPUs for VPN/Encryption usage. Those CPUs are blocked for normal usage but apear with 100% usage in the snmp mib.

To be able to use `--warningx cpu_0_usage=X --criticalx cpu_0_usage=Y` the set/check thresholds calls must be adjusted.