### PR TITLE
Ignore powersupply subsystem when checkpoint returns dummy values

### DIFF
--- a/plugins-scripts/Classes/CheckPoint/Firewall1/Component/PowersupplySubsystem.pm
+++ b/plugins-scripts/Classes/CheckPoint/Firewall1/Component/PowersupplySubsystem.pm
@@ -15,14 +15,17 @@ use strict;
 
 sub check {
   my $self = shift;
-  $self->add_info(sprintf 'power supply %d status is %s', 
-      $self->{powerSupplyIndex},
-      $self->{powerSupplyStatus});
-  if ($self->{powerSupplyStatus} eq 'Up') {
-    $self->add_ok();
-  } elsif ($self->{powerSupplyStatus} eq 'Down') {
-    $self->add_critical();
-  } else {
-    $self->add_unknown();
+  #Ignore Dummy values
+  if ($self->{powerSupplyStatus} ne 'Dummy') {
+    $self->add_info(sprintf 'power supply %d status is %s', 
+        $self->{powerSupplyIndex},
+        $self->{powerSupplyStatus});
+    if ($self->{powerSupplyStatus} eq 'Up') {
+      $self->add_ok();
+    } elsif ($self->{powerSupplyStatus} eq 'Down') {
+      $self->add_critical();
+    } else {
+      $self->add_unknown();
+    }
   }
 }


### PR DESCRIPTION
We noticed our Checkpoint 5400's were reporting Dummy values for the power supply status:

See snmpwalk output:
CHECKPOINT-MIB::powerSupplyStatus.1.0 = STRING: Dummy
CHECKPOINT-MIB::powerSupplyStatus.2.0 = STRING: Dummy

This resulted in UNKNOWN result for the plugin:
UNKNOWN - power supply 1 status is Dummy, power supply 2 status is Dummy, ...

After this change a Dummy value will be ignored (as if no value was present)

