### PR TITLE
Cleanup labels/thresholds for Checkpoint Firewall1

### DIFF
--- a/plugins-scripts/Classes/CheckPoint/Firewall1/Component/FanSubsystem.pm
+++ b/plugins-scripts/Classes/CheckPoint/Firewall1/Component/FanSubsystem.pm
@@ -33,9 +33,11 @@ sub check {
   } else {
     $self->add_unknown();
   }
-  $self->set_thresholds(warning => 60, critical => 70);
+  $self->set_thresholds(warning => 0, critical => 0);
+  my $neatFanSpeedSensorName = lc($self->{fanSpeedSensorName});
+  $neatFanSpeedSensorName =~ s/ /_/;
   $self->add_perfdata(
-      label => 'fan'.$self->{fanSpeedSensorName}.'_rpm',
+      label => 'fan_'.$neatFanSpeedSensorName,
       value => $self->{fanSpeedSensorValue},
   );
 }

--- a/plugins-scripts/Classes/CheckPoint/Firewall1/Component/TemperatureSubsystem.pm
+++ b/plugins-scripts/Classes/CheckPoint/Firewall1/Component/TemperatureSubsystem.pm
@@ -34,9 +34,11 @@ sub check {
   } else {
     $self->add_unknown();
   }
-  $self->set_thresholds(warning => 60, critical => 70);
+  $self->set_thresholds(warning => 0, critical => 0);
+  my $neatTemperatureSensorName = lc($self->{tempertureSensorName});
+  $neatTemperatureSensorName =~ s/ /_/;
   $self->add_perfdata(
-      label => 'temperature_'.$self->{tempertureSensorName},
+      label => 'temperature_'.$neatTemperatureSensorName,
       value => $self->{tempertureSensorValue},
   );
 }

--- a/plugins-scripts/Classes/CheckPoint/Firewall1/Component/VoltageSubsystem.pm
+++ b/plugins-scripts/Classes/CheckPoint/Firewall1/Component/VoltageSubsystem.pm
@@ -35,7 +35,7 @@ sub check {
   }
   $self->set_thresholds(warning => 60, critical => 70);
   $self->add_perfdata(
-      label => 'voltage'.$self->{voltageSensorName}.'_rpm',
+      label => 'voltage_'.lc($self->{voltageSensorName}),
       value => $self->{voltageSensorValue},
   );
 }

--- a/plugins-scripts/Classes/CheckPoint/Firewall1/Component/VoltageSubsystem.pm
+++ b/plugins-scripts/Classes/CheckPoint/Firewall1/Component/VoltageSubsystem.pm
@@ -33,7 +33,7 @@ sub check {
   } else {
     $self->add_unknown();
   }
-  $self->set_thresholds(warning => 60, critical => 70);
+  $self->set_thresholds(warning => 0, critical => 0);
   $self->add_perfdata(
       label => 'voltage_'.lc($self->{voltageSensorName}),
       value => $self->{voltageSensorValue},


### PR DESCRIPTION
Fan, Temperature and Voltage subsystems for Firewall1 had thresholds set to 60/70. In op5 (but probably also in other nagios derived systems) this means if the values are low (as in 5V or 12V voltage checks), the graph only shows in the bottom part as the thresholds are drawn in the top part of the graph. The graph shows less detail in this way. Also the thresholds are not actually used in status calculation (status is retreived from the device) so people looking at the graphs are somewhat mislead.

Additionally the labels for these subsytems are cleaned and unified (all lowercase and adding underscores is checkpoint supplied sensor name includes a space).