### PR TITLE
perfdata label prefixed by "member_" when related to a pool member

### DIFF
--- a/plugins-scripts/Classes/F5/F5BIGIP/Component/LTM.pm
+++ b/plugins-scripts/Classes/F5/F5BIGIP/Component/LTM.pm
@@ -433,7 +433,7 @@ sub check {
     }
   }
   if ($self->mode =~ /device::lb::pool::co.*ctions/) {
-    my $label = 'pool_'.$self->{ltmPoolMemberNodeName}.'_'.$self->{ltmPoolMemberPort};
+    my $label = 'member_'.$self->{ltmPoolMemberNodeName}.'_'.$self->{ltmPoolMemberPort};
     $self->set_thresholds(metric => $label.'_connections_pct', warning => "85", critical => "95");
     $self->add_info(sprintf "member %s:%s has %d connections (from max %dM)",
         $self->{ltmPoolMemberNodeName},


### PR DESCRIPTION
F5 bigip - performance data labels are prefixed by "pool_", even if it is related to a member and not a pool
#132