### PR TITLE
nsPowerDesc can be null

### DIFF
--- a/plugins-scripts/Classes/Juniper/NetScreen/Component/EnvironmentalSubsystem.pm
+++ b/plugins-scripts/Classes/Juniper/NetScreen/Component/EnvironmentalSubsystem.pm
@@ -45,8 +45,13 @@ use strict;
 
 sub check {
   my $self = shift;
-  $self->add_info(sprintf "power supply %s (%s) is %s",
+  if ($self->{nsPowerDesc}) {
+    $self->add_info(sprintf "power supply %s (%s) is %s",
       $self->{nsPowerId}, $self->{nsPowerDesc}, $self->{nsPowerStatus});
+  } else {
+    $self->add_info(sprintf "power supply %s is %s",
+      $self->{nsPowerId}, $self->{nsPowerStatus});
+  }
   if ($self->{nsPowerStatus} eq "good") {
     $self->add_ok();
   } elsif ($self->{nsPowerStatus} eq "fail") {


### PR DESCRIPTION
nsPowerDesc can be null, generating a warning when executing the check.

```
/usr/lib64/nagios/custom_plugins/check_nwc_health '--community' 'xxxx' '--hostname' 'xxxxx' '--mode' 'hardware-health'
Use of uninitialized value in sprintf at /usr/lib64/nagios/custom_plugins/check_nwc_health line 28667.
OK - fan 1 (IO Fan 1) is good, fan 2 (Memory Fan) is good, fan 3 (CPU Fan 1) is good, fan 4 (CPU Fan 2) is good, power supply 1 () is good, temperature 1 (CPU Temperature) is 30C, temperature 2 (System Temperature) is 24C | 'temp_1'=30;;;; 'temp_2'=24;;;;
```

==> power supply 1 () is good

This small fix avoid that perl warning.