### PR TITLE
Fix temporary file name when using interface-errors mode

### DIFF
--- a/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
+++ b/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
@@ -669,7 +669,7 @@ sub init {
       $self->{maxOutputRate} = 0;
     }
   } elsif ($self->mode =~ /device::interfaces::errors/) {
-    $self->valdiff({name => $self->{ifDescr}}, qw(ifInErrors ifOutErrors));
+    $self->valdiff({name => $self->{ifIndex}.'#'.$self->{ifDescr}}, qw(ifInErrors ifOutErrors));
     $self->{inputErrorRate} = $self->{delta_ifInErrors} 
         / $self->{delta_timestamp};
     $self->{outputErrorRate} = $self->{delta_ifOutErrors} 


### PR DESCRIPTION
Add Index to temporary file name - This fixes the case of errors not being monitored correctly if ifDescr is not unique per port