### PR TITLE
Support for Eltex MES Managed Switches.

### DIFF
--- a/plugins-scripts/Classes/Device.pm
+++ b/plugins-scripts/Classes/Device.pm
@@ -31,6 +31,7 @@ sub classify {
       $self->{productname} = 'hh3c' if $self->opts->servertype eq 'hh3c';
       $self->{productname} = 'hp' if $self->opts->servertype eq 'hp';
       $self->{productname} = 'brocade' if $self->opts->servertype eq 'brocade';
+      $self->{productname} = 'eltex' if $self->opts->servertype eq 'eltex';
       $self->{productname} = 'netscreen' if $self->opts->servertype eq 'netscreen';
       $self->{productname} = 'junos' if $self->opts->servertype eq 'junos';
       $self->{productname} = 'linuxlocal' if $self->opts->servertype eq 'linuxlocal';
@@ -90,6 +91,9 @@ sub classify {
       } elsif ($self->{productname} =~ /(Linux cumulus)|(Cumulus Linux)/i) {
         bless $self, 'Classes::Cumulus';
         $self->debug('using Classes::Cumulus');
+      } elsif ($self->{productname} =~ /MES/i) {
+        bless $self, 'Classes::Eltex';
+        $self->debug('using Classes::Eltex');
       } elsif ($self->{productname} =~ /DS_4100/i) {
         bless $self, 'Classes::Brocade';
         $self->debug('using Classes::Brocade');
@@ -179,7 +183,7 @@ sub classify {
         bless $self, 'Classes::Foundry';
         $self->debug('using Classes::Foundry');
       } elsif ($self->{productname} =~ /IronWare/i) {
-        # although there can be a 
+        # although there can be a
         # Brocade Communications Systems, Inc. FWS648, IronWare Version 07.1....
         bless $self, 'Classes::Foundry';
         $self->debug('using Classes::Foundry');
@@ -274,4 +278,3 @@ sub init {
     $self->no_such_mode();
   }
 }
-

--- a/plugins-scripts/Classes/Eltex.pm
+++ b/plugins-scripts/Classes/Eltex.pm
@@ -1,0 +1,19 @@
+package Classes::Eltex;
+our @ISA = qw(Classes::Device);
+use strict;
+
+sub init {
+  my $self = shift;
+  if ($self->{productname} =~ /(MES2324B)|(MES2324F)|(MES31)|(MES53)/i) {
+    bless $self, 'Classes::Eltex::Aggregation';
+    $self->debug('using Classes::Eltex::Aggregation');
+  } elsif ($self->{productname} =~ /(MES21)|(MES23)/i) {
+    bless $self, 'Classes::Eltex::Access';
+    $self->debug('using Classes::Eltex::Access');
+  }
+  if (ref($self) ne "Classes::Eltex") {
+    $self->init();
+  } else {
+    $self->no_such_mode();
+  }
+}

--- a/plugins-scripts/Classes/Eltex/Access.pm
+++ b/plugins-scripts/Classes/Eltex/Access.pm
@@ -1,0 +1,27 @@
+package Classes::Eltex::Access;
+our @ISA = qw(Classes::Eltex);
+use strict;
+
+# MES2100: 1 PSU, no FAN
+# MES2124P: 1 PSU, 2 FAN
+# MES2308: 1 PSU, no FAN
+# MES2324: 1 PSU, no FAN
+# MES2326: 1 PSU, no FAN
+# MES2348: 1 PSU, 2 FAN
+
+sub init {
+  my $self = shift;
+  if ($self->mode =~ /device::hardware::load/) {
+    $self->analyze_and_check_cpu_subsystem('Classes::Eltex::MES::Component::CpuSubsystem');
+  } elsif ($self->mode =~ /device::hardware::health/) {
+    $self->analyze_and_check_environmental_subsystem('Classes::Eltex::Access::Component::EnvironmentalSubsystem');
+    if (! $self->check_messages()) {
+      $self->clear_messages(0);
+      $self->add_ok('environmental hardware working fine');
+    }
+  } elsif ($self->mode =~ /device::ha::status/) {
+    $self->analyze_and_check_ha_subsystem('Classes::Eltex::MES::Component::HaSubsystem');
+  } else {
+    $self->no_such_mode();
+  }
+}

--- a/plugins-scripts/Classes/Eltex/Access/Component/EnvironmentalSubsystem.pm
+++ b/plugins-scripts/Classes/Eltex/Access/Component/EnvironmentalSubsystem.pm
@@ -1,0 +1,51 @@
+package Classes::Eltex::Access::Component::EnvironmentalSubsystem;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my $self = shift;
+  $self->get_snmp_tables('ELTEX-MIB', [
+      ['fans', 'eltexFanTable', 'Classes::Eltex::Access::Component::EnvironmentalSubsystem::Fan'],
+      ['temperatures', 'eltexSensorTable', 'Classes::Eltex::Access::Component::EnvironmentalSubsystem::Temperature']
+  ]);
+}
+
+sub check {
+  my $self = shift;
+  foreach (@{$self->{fans}}, @{$self->{temperatures}}) {
+    $_->check();
+  }
+}
+package Classes::Eltex::Access::Component::EnvironmentalSubsystem::Fan;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::TableItem);
+use strict;
+
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf '%s is %s',
+    $self->{eltexFanDescription}, $self->{eltexFanStatus});
+  if ($self->{eltexFanStatus} eq 'normal') {
+    $self->add_ok();
+  } elsif ($self->{eltexFanStatus} eq 'notPresent') {
+    $self->add_warning();
+  } elsif ($self->{eltexFanStatus} eq 'unknown') {
+    $self->add(); # Actually fan is not present on device, but in index...
+  }
+}
+
+package Classes::Eltex::Access::Component::EnvironmentalSubsystem::Temperature;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::TableItem);
+use strict;
+
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf 'sensor %s is %s°C',
+    $self->{eltexSensorDescription}, $self->{eltexSensorStatus});
+  $self->set_thresholds(warning => 55, critical => 65);
+  $self->add_message($self->check_thresholds($self->{eltexSensorStatus}));
+  $self->add_perfdata(
+    label => 'sensor_'.$self->{eltexSensorDescription}.'_temp',
+    value => $self->{eltexSensorStatus},
+    uom => '°C',
+  );
+}

--- a/plugins-scripts/Classes/Eltex/Aggregation.pm
+++ b/plugins-scripts/Classes/Eltex/Aggregation.pm
@@ -1,0 +1,25 @@
+package Classes::Eltex::Aggregation;
+our @ISA = qw(Classes::Eltex);
+use strict;
+
+# MES2324B: 2 PSU, no FAN
+# MES2324F, MES2324FB: 2 PSU, 4 FAN
+# MES3108, MES3116, MES3124, MES3224: 2 PSU, 4 FAN
+# MES5324: 2 PSU, 4 FAN
+
+sub init {
+  my $self = shift;
+  if ($self->mode =~ /device::hardware::load/) {
+    $self->analyze_and_check_cpu_subsystem('Classes::Eltex::MES::Component::CpuSubsystem');
+  } elsif ($self->mode =~ /device::hardware::health/) {
+    $self->analyze_and_check_environmental_subsystem('Classes::Eltex::Aggregation::Component::EnvironmentalSubsystem');
+    if (! $self->check_messages()) {
+      $self->clear_messages(0);
+      $self->add_ok('environmental hardware working fine');
+    }
+  } elsif ($self->mode =~ /device::ha::status/) {
+    $self->analyze_and_check_ha_subsystem('Classes::Eltex::MES::Component::HaSubsystem');
+  } else {
+    $self->no_such_mode();
+  }
+}

--- a/plugins-scripts/Classes/Eltex/Aggregation/Component/EnvironmentalSubsystem.pm
+++ b/plugins-scripts/Classes/Eltex/Aggregation/Component/EnvironmentalSubsystem.pm
@@ -1,0 +1,68 @@
+package Classes::Eltex::Aggregation::Component::EnvironmentalSubsystem;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my $self = shift;
+  $self->get_snmp_tables('ELTEX-MIB', [
+      ['fans', 'eltexFanTable', 'Classes::Eltex::Aggregation::Component::EnvironmentalSubsystem::Fan'],
+      ['temperatures', 'eltexSensorTable', 'Classes::Eltex::Aggregation::Component::EnvironmentalSubsystem::Temperature'],
+      ['power', 'eltexPowerSupplyTable', 'Classes::Eltex::Aggregation::Component::EnvironmentalSubsystem::Power'],
+  ]);
+}
+
+sub check {
+  my $self = shift;
+  foreach (@{$self->{fans}}, @{$self->{temperatures}}, @{$self->{power}}) {
+    $_->check();
+  }
+}
+
+package Classes::Eltex::Aggregation::Component::EnvironmentalSubsystem::Fan;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::TableItem);
+use strict;
+
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf '%s is %s',
+    $self->{eltexFanDescription}, $self->{eltexFanStatus});
+  if ($self->{eltexFanStatus} eq 'normal') {
+    $self->add_ok();
+  } elsif ($self->{eltexFanStatus} eq 'notPresent') {
+    $self->add_warning();
+  }
+}
+
+package Classes::Eltex::Aggregation::Component::EnvironmentalSubsystem::Temperature;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::TableItem);
+use strict;
+
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf 'sensor %s is %s°C',
+    $self->{eltexSensorDescription}, $self->{eltexSensorStatus});
+  $self->set_thresholds(warning => 55, critical => 65);
+  $self->add_message($self->check_thresholds($self->{eltexSensorStatus}));
+  $self->add_perfdata(
+    label => 'sensor_'.$self->{eltexSensorDescription}.'_temp',
+    value => $self->{eltexSensorStatus},
+    uom => '°C',
+  );
+}
+
+package Classes::Eltex::Aggregation::Component::EnvironmentalSubsystem::Power;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::TableItem);
+use strict;
+
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf '%s is %s',
+    $self->{eltexPowerSupplyDescription}, $self->{eltexPowerSupplyStatus});
+  if ($self->{eltexPowerSupplyStatus} eq 'normal') {
+    $self->add_ok();
+  } elsif ($self->{eltexPowerSupplyStatus} eq 'notPresent') {
+    $self->add_warning();
+  } elsif ($self->{eltexPowerSupplyStatus} eq 'notFunctioning') {
+    $self->add_critical();
+  }
+}

--- a/plugins-scripts/Classes/Eltex/MES/Component/CpuSubsystem.pm
+++ b/plugins-scripts/Classes/Eltex/MES/Component/CpuSubsystem.pm
@@ -1,0 +1,34 @@
+package Classes::Eltex::MES::Component::CpuSubsystem;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my $self = shift;
+  $self->get_snmp_objects('ELTEX-MIB', (qw(
+      eltexCpuUtilisationLastSecond eltexCpuUtilisationOneMinute
+      eltexCpuUtilisationFiveMinutes)));
+}
+
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf 'cpu usage is %s%%',
+    $self->{eltexCpuUtilisationLastSecond});
+  $self->set_thresholds(warning => 50, critical => 90);
+  $self->add_message($self->check_thresholds(
+    $self->{eltexCpuUtilisationLastSecond}));
+  $self->add_perfdata(
+    label => 'cpu_usage',
+    value => $self->{eltexCpuUtilisationLastSecond},
+    uom => '%',
+  );
+  $self->add_perfdata(
+    label => 'cpu_usage_one_minute',
+    value => $self->{eltexCpuUtilisationOneMinute},
+    uom => '%',
+  );
+  $self->add_perfdata(
+    label => 'cpu_usage_five_minutes',
+    value => $self->{eltexCpuUtilisationFiveMinutes},
+    uom => '%',
+  );
+}

--- a/plugins-scripts/Classes/Eltex/MES/Component/HaSubsystem.pm
+++ b/plugins-scripts/Classes/Eltex/MES/Component/HaSubsystem.pm
@@ -1,0 +1,29 @@
+package Classes::Eltex::MES::Component::HaSubsystem;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my $self = shift;
+  $self->get_snmp_objects('ELTEX-MIB', (qw(eltexStackUnitsNumber)));
+}
+
+# Specify threshold values, so that you understand when the number of units
+# decreases, for example we have only 2 units in stack, so we should get
+# warning state if one of unit goes down:
+# ./check_nwc_health --hostname 10.10.10.2 --mode ha-status --warning 2:
+# OK - stack have 2 units | 'units'=2;2:;0:;;
+# and when only one unit left:
+# WARNING - stack have 1 units | 'units'=1;2:;0:;;
+
+sub check {
+  my $self = shift;
+  $self->add_info(sprintf 'stack have %s units',
+    $self->{eltexStackUnitsNumber});
+  $self->set_thresholds(warning => '0:', critical => '0:');
+  $self->add_message($self->check_thresholds(
+    $self->{eltexStackUnitsNumber}));
+  $self->add_perfdata(
+    label => 'units',
+    value => $self->{eltexStackUnitsNumber},
+  );
+}

--- a/plugins-scripts/Makefile.am
+++ b/plugins-scripts/Makefile.am
@@ -54,6 +54,7 @@ GL_MODULES=\
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/CISCOVTPMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/CLAVISTERMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/DISKMIB.pm \
+  ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/ELTEXMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/ENTITYMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/ENTITYSENSORMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/ENTITYSTATEMIB.pm \
@@ -375,6 +376,13 @@ EXTRA_MODULES=\
   Classes/PaloAlto.pm \
   Classes/Bluecoat.pm \
   Classes/Cumulus.pm \
+  Classes/Eltex/Access/Component/EnvironmentalSubsystem.pm \
+  Classes/Eltex/Access.pm \
+  Classes/Eltex/Aggregation/Component/EnvironmentalSubsystem.pm \
+  Classes/Eltex/Aggregation.pm \
+  Classes/Eltex/MES/Component/CpuSubsystem.pm \
+  Classes/Eltex/MES/Component/HaSubsystem.pm \
+  Classes/Eltex.pm \
   Classes/Netgear.pm \
   Classes/Lantronix.pm \
   Classes/Lantronix/SLS.pm \
@@ -438,4 +446,3 @@ $(libexec_SCRIPTS) : $(EXTRA_DIST)
 	$(ECHO) "package main;" >> $@
 	$(CAT) $(libexec_SCRIPTS).pl | $(AWK) -f ./subst >> $@
 	chmod +x $@
-


### PR DESCRIPTION
Added support for [Eltex](http://eltex-co.ru/en) MES devices.
Tested on Access & Aggregation [MES devices](http://eltex-co.ru/en/catalog/networking/) that I have.
`eltexSensorDescription` is empty string. Later I will report to the manufacturer about this issue.


MES3124:
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.129.1 --mode hardware-health
OK - environmental hardware working fine | 'sensor__temp'=29°C;55;65;; 'sensor__temp'=33°C;55;65;; 'sensor__temp'=36°C;55;65;;
```
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.129.1 --mode hardware-health -v
I am a MES3124 28-port 1G/10G Managed Switch
OK - environmental hardware working fine
fan1_unit1 is normal
fan2_unit1 is normal
fan3_unit1 is normal
fan4_unit1 is normal
sensor  is 29°C
sensor  is 33°C
sensor  is 36°C
ps1_unit1 is normal
ps2_unit1 is normal | 'sensor__temp'=29°C;55;65;; 'sensor__temp'=33°C;55;65;; 'sensor__temp'=36°C;55;65;;
```
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.129.1 --mode cpu-load -v
I am a MES3124 28-port 1G/10G Managed Switch
OK - cpu usage is 22%
cpu usage is 22% | 'cpu_usage'=22%;50;90;0;100 'cpu_usage_one_minute'=5%;50;90;0;100 'cpu_usage_five_minutes'=3%;50;90;0;100
```

MES5324:
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.129.59 --mode hardware-health
OK - environmental hardware working fine | 'sensor__temp'=38°C;55;65;; 'sensor__temp'=34°C;55;65;; 'sensor__temp'=29°C;55;65;; 'sensor__temp'=35°C;55;65;;
```
```shell
I am a MES5324 28-port 10G/40G Managed Switch
OK - environmental hardware working fine
fan1_unit1 is normal
fan2_unit1 is normal
fan3_unit1 is normal
fan4_unit1 is normal
sensor  is 38°C
sensor  is 34°C
sensor  is 29°C
sensor  is 35°C
ps1_unit1 is normal
ps2_unit1 is normal | 'sensor__temp'=38°C;55;65;; 'sensor__temp'=34°C;55;65;; 'sensor__temp'=29°C;55;65;; 'sensor__temp'=35°C;55;65;;
```
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.129.59 --mode cpu-load -v
I am a MES5324 28-port 10G/40G Managed Switch
OK - cpu usage is 5%
cpu usage is 5% | 'cpu_usage'=5%;50;90;0;100 'cpu_usage_one_minute'=5%;50;90;0;100 'cpu_usage_five_minutes'=5%;50;90;0;100
```

MES2124P (have only 2 fans on chassis and only one PSU):
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.129.6 --mode hardware-health
OK - environmental hardware working fine | 'sensor__temp'=32°C;55;65;;
```
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.129.6 --mode hardware-health -v
I am a MES2124P rev.C 28-port 1G Managed Switch with 24 POE+ ports
OK - environmental hardware working fine
fan1_unit1 is normal
fan2_unit1 is normal
fan3_unit1 is unknown
fan4_unit1 is unknown
fan5_unit1 is unknown
sensor  is 32°C | 'sensor__temp'=32°C;55;65;;
```
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.129.6 --mode cpu-load -v
I am a MES2124P rev.C 28-port 1G Managed Switch with 24 POE+ ports
OK - cpu usage is 5%
cpu usage is 5% | 'cpu_usage'=5%;50;90;0;100 'cpu_usage_one_minute'=5%;50;90;0;100 'cpu_usage_five_minutes'=5%;50;90;0;100
```

MES2324 (fanless with one PSU):
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.2.1 --mode hardware-health
OK - environmental hardware working fine | 'sensor__temp'=31°C;55;65;;
```
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.2.1 --mode hardware-health -v
I am a MES2324 28-port 1G/10G Managed Switch
OK - environmental hardware working fine
fan1_unit1 is unknown
fan2_unit1 is unknown
fan3_unit1 is unknown
fan4_unit1 is unknown
sensor  is 31°C | 'sensor__temp'=31°C;55;65;;
```
```shell
[k0ste@WorkStation check_nwc_health]$ ./plugins-scripts/check_nwc_health --hostname 10.100.2.1 --mode cpu-load -v
I am a MES2324 28-port 1G/10G Managed Switch
OK - cpu usage is 4%
cpu usage is 4% | 'cpu_usage'=4%;50;90;0;100 'cpu_usage_one_minute'=5%;50;90;0;100 'cpu_usage_five_minutes'=4%;50;90;0;100
```