### PR TITLE
Update TemperatureSubsystem.pm

### DIFF
--- a/plugins-scripts/Classes/Foundry/Component/TemperatureSubsystem.pm
+++ b/plugins-scripts/Classes/Foundry/Component/TemperatureSubsystem.pm
@@ -56,7 +56,7 @@ sub finish {
   my $self = shift;
   ($self->{snAgentTempSlotNum}, $self->{snAgentTempSensorId}) =
       @{$self->{indices}};
-  $self->{snAgentTempValue} /= 2;
+  $self->{snAgentTempValue} /= 2 if ($self->{snAgentTempValue});
   $self->{label} = sprintf 'temperature_%s:%s',
       $self->{snAgentTempSensorId},
       $self->{snAgentTempSlotNum};
@@ -64,6 +64,7 @@ sub finish {
 
 sub check {
   my $self = shift;
+  return if (!$self->{snAgentTempValue});
   $self->add_info(sprintf 'temperature %s in slot %s is %.2fC', 
       $self->{snAgentTempSensorId},
       $self->{snAgentTempSlotNum}, $self->{snAgentTempValue});


### PR DESCRIPTION
Equipement have 2 null values ont temperature oid

SNMPv2-SMI::enterprises.1991.1.1.2.13.1.1.4.11.1 = INTEGER: 56
SNMPv2-SMI::enterprises.1991.1.1.2.13.1.1.4.11.2 = NULL
SNMPv2-SMI::enterprises.1991.1.1.2.13.1.1.4.11.3 = INTEGER: 56
SNMPv2-SMI::enterprises.1991.1.1.2.13.1.1.4.12.1 = INTEGER: 60
SNMPv2-SMI::enterprises.1991.1.1.2.13.1.1.4.12.2 = NULL
SNMPv2-SMI::enterprises.1991.1.1.2.13.1.1.4.12.3 = INTEGER: 60

So script genrate warnings.

This modification fix it.

So i don't know there are no value on this probe, is it really a issue ?