### PR TITLE
Update AVM.pm

### DIFF
--- a/plugins-scripts/Classes/UPNP/AVM.pm
+++ b/plugins-scripts/Classes/UPNP/AVM.pm
@@ -4,7 +4,7 @@ use strict;
 
 sub init {
   my ($self) = @_;
-  if ($self->{productname} =~ /7390/) {
+  if ($self->{productname} =~ /(7390|7490)/) {
     bless $self, 'Classes::UPNP::AVM::FritzBox7390';
     $self->debug('using Classes::UPNP::AVM::FritzBox7390');
   } elsif ($self->{productname} =~ /7490/) {


### PR DESCRIPTION
add support for fritzbox 7490. Only mode i tested so far is `--mode smart-home-device-energy`. Looking at the changelog, the 7390 and 7490 should be almost identical and have the same software running.