### PR TITLE
Basic Huawei S series support

### DIFF
--- a/plugins-scripts/Classes/Device.pm
+++ b/plugins-scripts/Classes/Device.pm
@@ -127,6 +127,8 @@ sub classify {
         $self->rebless('Classes::HH3C');
       } elsif ($self->{productname} =~ /(Huawei)/i) {
         $self->rebless('Classes::Huawei');
+      } elsif (($self->{productname} =~ /^S\d{4,}-/)) {
+        $self->rebless('Classes::Huawei');
       } elsif ($self->{productname} =~ /Procurve/i ||
           ($self->implements_mib('HP-ICF-CHASSIS-MIB') &&
           $self->implements_mib('NETSWITCH-MIB'))) {

--- a/plugins-scripts/Classes/Huawei.pm
+++ b/plugins-scripts/Classes/Huawei.pm
@@ -9,6 +9,10 @@ sub init {
     bless $self, 'Classes::Huawei::CloudEngine';
     $self->debug('using Classes::Huawei::CloudEngine');
   }
+  elsif ($sysobj =~ /^\.1\.3\.6\.1\.4\.1\.2011\.2\.23\./) {
+    bless $self, 'Classes::Huawei::SSeries';
+    $self->debug('using Classes::Huawei::SSeries');
+  }
   if (ref($self) ne "Classes::Huawei") {
     $self->init();
   }

--- a/plugins-scripts/Classes/Huawei/Component/EnvironmentalSubsystem.pm
+++ b/plugins-scripts/Classes/Huawei/Component/EnvironmentalSubsystem.pm
@@ -84,6 +84,10 @@ sub finish {
 
 sub check {
   my ($self) = @_;
+
+  # Does this module provide any meaningful data?
+  return if $self->{hwEntityFaultLight} eq 'notSupported';
+
   $self->add_info(sprintf 'module %s admin status is %s, oper status is %s',
       $self->{name}, $self->{hwEntityAdminStatus}, $self->{hwEntityOperStatus});
   $self->add_info(sprintf 'module %s temperature is %.2f',

--- a/plugins-scripts/Classes/Huawei/SSeries.pm
+++ b/plugins-scripts/Classes/Huawei/SSeries.pm
@@ -1,0 +1,19 @@
+package Classes::Huawei::SSeries;
+our @ISA = qw(Classes::Huawei);
+use strict;
+
+sub init {
+  my ($self) = @_;
+
+  if ($self->mode =~ /device::hardware::health/) {
+    $self->analyze_and_check_environmental_subsystem("Classes::Huawei::Component::EnvironmentalSubsystem");
+  } elsif ($self->mode =~ /device::hardware::load/) {
+    $self->analyze_and_check_cpu_subsystem("Classes::Huawei::Component::CpuSubsystem");
+  } elsif ($self->mode =~ /device::hardware::memory/) {
+    $self->analyze_and_check_mem_subsystem("Classes::Huawei::Component::MemSubsystem");
+  } else {
+    $self->no_such_mode();
+  }
+}
+
+__END__

--- a/plugins-scripts/Classes/Huawei/SSeries.pm
+++ b/plugins-scripts/Classes/Huawei/SSeries.pm
@@ -8,9 +8,9 @@ sub init {
   if ($self->mode =~ /device::hardware::health/) {
     $self->analyze_and_check_environmental_subsystem("Classes::Huawei::Component::EnvironmentalSubsystem");
   } elsif ($self->mode =~ /device::hardware::load/) {
-    $self->analyze_and_check_cpu_subsystem("Classes::Huawei::Component::CpuSubsystem");
+    $self->analyze_and_check_cpu_subsystem("Classes::Huawei::SSeries::CpuSubsystem");
   } elsif ($self->mode =~ /device::hardware::memory/) {
-    $self->analyze_and_check_mem_subsystem("Classes::Huawei::Component::MemSubsystem");
+    $self->analyze_and_check_mem_subsystem("Classes::Huawei::SSeries::MemSubsystem");
   } else {
     $self->no_such_mode();
   }

--- a/plugins-scripts/Classes/Huawei/SSeries/CpuSubsystem.pm
+++ b/plugins-scripts/Classes/Huawei/SSeries/CpuSubsystem.pm
@@ -1,0 +1,39 @@
+package Classes::Huawei::SSeries::CpuSubsystem;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my ($self) = @_;
+  $self->get_snmp_tables('HUAWEI-CPU-MIB', [
+      ['devs', 'hwCpuDevTable', 'Classes::Huawei::SSeries::CpuSubsystem::Cpu', sub { defined($_[0]->{hwCpuDevDuty}) }, [qw/hwCpuDevDuty/]],
+    ],
+  );
+}
+
+
+package Classes::Huawei::SSeries::CpuSubsystem::Cpu;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::TableItem);
+use strict;
+
+sub finish {
+  my ($self) = @_;
+  $self->{name} = $self->{indices}->[1];
+}
+
+sub check {
+  my ($self, $id) = @_;
+  $self->add_info(sprintf 'CPU %s usage is %s%%',
+      $self->{name}, $self->{hwCpuDevDuty});
+  $self->add_message(
+      $self->check_thresholds(
+          metric => 'cpu_'.$self->{name},
+          value => $self->{hwCpuDevDuty}
+  ));
+  $self->add_perfdata(
+      label => 'cpu_'.$self->{name},
+      value => $self->{hwCpuDevDuty},
+      uom => '%',
+  );
+}
+
+__END__

--- a/plugins-scripts/Classes/Huawei/SSeries/MemSubsystem.pm
+++ b/plugins-scripts/Classes/Huawei/SSeries/MemSubsystem.pm
@@ -1,0 +1,46 @@
+package Classes::Huawei::SSeries::MemSubsystem;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my ($self) = @_;
+
+  $self->get_snmp_tables('HUAWEI-MEMORY-MIB', [
+      [ 'devs', 'hwMemoryDevTable', 'Classes::Huawei::SSeries::MemSubsystem::Mem', sub { $_[0]->{hwMemoryDevSize} }, [qw/hwMemoryDevSize hwMemoryDevFree/]],
+    ],
+  );
+}
+
+
+package Classes::Huawei::SSeries::MemSubsystem::Mem;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::TableItem);
+use strict;
+
+sub finish {
+  my ($self) = @_;
+  $self->{name} = $self->{indices}->[1];
+}
+
+sub check {
+  my ($self) = @_;
+
+  my $total = $self->{hwMemoryDevSize} / 1024 / 1024;
+  my $free = $self->{hwMemoryDevFree} / 1024 / 1024;
+  my $used = $total - $free;
+  my $usage = int(100 / $total * $used);
+
+  $self->add_info(sprintf 'Memory unit#%s usage is %s%% (%dMB of %dMB)',
+      $self->{name}, $usage, $used, $total);
+  $self->add_message(
+      $self->check_thresholds(
+          metric => 'mem_'.$self->{name},
+          value => $used
+  ));
+  $self->add_perfdata(
+      label => 'mem_'.$self->{name},
+      value => $usage,
+      uom => '%',
+  );
+}
+
+__END__

--- a/plugins-scripts/Makefile.am
+++ b/plugins-scripts/Makefile.am
@@ -252,6 +252,7 @@ EXTRA_MODULES=\
   Classes/Huawei/Component/CpuSubsystem.pm \
   Classes/Huawei/Component/MemSubsystem.pm \
   Classes/Huawei/CloudEngine.pm \
+  Classes/Huawei/SSeries.pm \
   Classes/Huawei.pm \
   Classes/HP/Procurve/Component/MemSubsystem.pm \
   Classes/HP/Procurve/Component/CpuSubsystem.pm \

--- a/plugins-scripts/Makefile.am
+++ b/plugins-scripts/Makefile.am
@@ -252,6 +252,8 @@ EXTRA_MODULES=\
   Classes/Huawei/Component/CpuSubsystem.pm \
   Classes/Huawei/Component/MemSubsystem.pm \
   Classes/Huawei/CloudEngine.pm \
+  Classes/Huawei/SSeries/CpuSubsystem.pm \
+  Classes/Huawei/SSeries/MemSubsystem.pm \
   Classes/Huawei/SSeries.pm \
   Classes/Huawei.pm \
   Classes/HP/Procurve/Component/MemSubsystem.pm \

--- a/plugins-scripts/Makefile.am
+++ b/plugins-scripts/Makefile.am
@@ -70,6 +70,9 @@ GL_MODULES=\
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/GENUAMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HH3CENTITYEXTMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HUAWEIENTITYEXTENTMIB.pm \
+  ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HUAWEICPUMIB.pm \
+  ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HUAWEIMEMORYMIB.pm \
+  ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HUAWEIENERGYMNGTMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HOSTRESOURCESMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/HPICFCHASSISMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/IANAIFTYPEMIB.pm \


### PR DESCRIPTION
This PR adds basic support for the Huawei S series of networking switches.

This currently supports cpu-load, memory-usage and hardware-health modes, with the notable exception of any form of PSU checks in hardware-health. This will be added at a later date.

As usual, this PR depends on the corresponding GLPlugin PR that adds the necessary MIBs.