### PR TITLE
fix AsynOS 12.x support

### DIFF
--- a/plugins-scripts/Classes/Cisco.pm
+++ b/plugins-scripts/Classes/Cisco.pm
@@ -11,7 +11,7 @@ sub init {
     # die AIRESPACE-WIRELESS-MIB haben manchmal auch stinknormale Switche,
     # das hat also nichts zu sagen. SWITCHING ist entscheidend.
     $self->rebless('Classes::Cisco::WLC');
-  } elsif ($self->{productname} =~ /Cisco.*(IronPort|AsyncOS)/i) {
+  } elsif ($self->{productname} =~ /(IronPort|AsyncOS)/i) {
     $self->rebless('Classes::Cisco::AsyncOS');
   } elsif ($self->{productname} =~ /Cisco.*Prime Network Control System/i) {
     $self->rebless('Classes::Cisco::PrimeNCS');

--- a/plugins-scripts/Classes/Device.pm
+++ b/plugins-scripts/Classes/Device.pm
@@ -63,6 +63,8 @@ sub classify {
         $self->rebless('Classes::Cisco');
       } elsif ($self->{productname} =~ /fujitsu intelligent blade panel 30\/12/i) {
         $self->rebless('Classes::Cisco');
+      } elsif ($self->{productname} =~ /IronPort/i) {
+        $self->rebless('Classes::Cisco');
       } elsif ($self->{productname} =~ /UCOS /i) {
         $self->rebless('Classes::Cisco');
       } elsif ($self->{productname} =~ /Nortel/i) {


### PR DESCRIPTION
After an update from AsyncOS 11.x to 12.x, the sysDESCR of the appliance changes so that it is no longer recognized.

Examples:
Cisco IronPort Model M1070, AsyncOS Version: 11.0.1-152, Build Date: 2018-12-08, ...
IronPort Model M600V, AsyncOS Version: 12.5.0-636, Build Date: 2019-07-25, ...