### PR TITLE
Support for BlueCoat CAS systems added

### DIFF
--- a/plugins-scripts/Classes/Bluecoat.pm
+++ b/plugins-scripts/Classes/Bluecoat.pm
@@ -14,6 +14,10 @@ sub init {
     # product Blue Coat AV510 Series, ProxyAV Version: 3.5.1.1, Release id: 111017
     bless $self, 'Classes::AVOS';
     $self->debug('using Classes::AVOS');
+  } elsif ($self->{productname} =~ /Blue.*Coat.*S\d+-/i) {
+    # product Blue Coat S400-A1, Version: 1.3.7.8, Release Id: 225795
+    bless $self, 'Classes::CAS';
+    $self->debug('using Classes::CAS');
   }
   if (ref($self) ne "Classes::Bluecoat") {
     $self->init();

--- a/plugins-scripts/Classes/CAS.pm
+++ b/plugins-scripts/Classes/CAS.pm
@@ -1,0 +1,17 @@
+package Classes::CAS;
+our @ISA = qw(Classes::Bluecoat);
+use strict;
+
+sub init {
+  my ($self) = @_;
+  $self->debug('Classes::CAS');
+  if ($self->mode =~ /device::hardware::load/) {
+    $self->analyze_and_check_cpu_subsystem("Classes::CAS::Component::CpuSubsystem");
+  } elsif ($self->mode =~ /device::hardware::health/) {
+    $self->analyze_and_check_environmental_subsystem("Classes::SGOS::Component::EnvironmentalSubsystem");
+  } elsif ($self->mode =~ /device::hardware::memory/) {
+    $self->analyze_and_check_mem_subsystem("Classes::AVOS::Component::MemSubsystem");
+  } else {
+    $self->no_such_mode();
+  }
+}

--- a/plugins-scripts/Classes/CAS/Component/CpuSubsystem.pm
+++ b/plugins-scripts/Classes/CAS/Component/CpuSubsystem.pm
@@ -1,0 +1,27 @@
+package Classes::CAS::Component::CpuSubsystem;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my ($self) = @_;
+  $self->get_snmp_tables('USAGE-MIB', [
+        ['cpus', 'deviceUsageTable', 'Classes::CAS::Component::CpuSubsystem::Cpu', sub { return shift->{deviceUsageName} =~ /CPU/ }],
+    ]);
+}
+
+package Classes::CAS::Component::CpuSubsystem::Cpu;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::TableItem);
+use strict;
+
+sub check {
+  my ($self) = @_;
+  $self->add_info(sprintf 'cpu %s usage is %.2f%%',
+      $self->{flat_indices}, $self->{deviceUsagePercent});
+  $self->set_thresholds(warning => 80, critical => 90);
+  $self->add_message($self->check_thresholds($self->{deviceUsagePercent}));
+  $self->add_perfdata(
+      label => 'cpu_'.$self->{flat_indices}.'_usage',
+      value => $self->{deviceUsagePercent},
+      uom => '%',
+  );
+}

--- a/plugins-scripts/Makefile.am
+++ b/plugins-scripts/Makefile.am
@@ -363,6 +363,8 @@ EXTRA_MODULES=\
   Classes/SGOS/Component/SecuritySubsystem.pm \
   Classes/SGOS/Component/ConnectionSubsystem.pm \
   Classes/SGOS.pm \
+  Classes/CAS/Component/CpuSubsystem.pm \
+  Classes/CAS.pm \
   Classes/AVOS/Component/KeySubsystem.pm \
   Classes/AVOS/Component/SecuritySubsystem.pm \
   Classes/AVOS/Component/ConnectionSubsystem.pm \


### PR DESCRIPTION
Handle BlueCoat CAS as valid device. Added own component for CPU checks, as another mib is used compared to other BlueCoat devices.