### PR TITLE
Monitor CRC with interface-etherstats

### DIFF
--- a/plugins-scripts/Classes/Cisco/OLDCISCOINTERFACESMIB/Component/InterfaceSubsystem.pm
+++ b/plugins-scripts/Classes/Cisco/OLDCISCOINTERFACESMIB/Component/InterfaceSubsystem.pm
@@ -66,6 +66,7 @@ sub init {
       push(@rmontable_columns, qw(
         locIfDescr
         locIfHardType
+        locIfInCRC
       ));
     }
   } else {


### PR DESCRIPTION
In my case, CRC's is a major indicator for Layer1 faults. Please advice if this is the wrong way to go

`OK - interface TenGigabitEthernet1/0/1 (alias FooUPLINK) locIfInCRCPercent is 0.01%, interface TenGigabitEthernet1/0/1 (alias FooUPLINK) locIfInCRCPercent is 0.01% | 'TenGigabitEthernet1/0/1_inCRCPercent'=0.01%;1;10;0;100 'TenGigabitEthernet1/0/1_inCRCPercent'=0.01%;1;10;0;100
`

Also, can somebody give me a hint how to change the unit to packets instead of percent?
On >10G Links percent is not accurate enough

Thanks! what a nice plugin!