### PR TITLE
Add vpn sessions for Checkpoint FW-1

### DIFF
--- a/plugins-scripts/Classes/CheckPoint/Firewall1.pm
+++ b/plugins-scripts/Classes/CheckPoint/Firewall1.pm
@@ -21,6 +21,8 @@ sub init {
     $self->analyze_and_check_mngmt_subsystem("Classes::CheckPoint::Firewall1::Component::MngmtSubsystem");
   } elsif ($self->mode =~ /device::vpn::status/) {
     $self->analyze_and_check_config_subsystem("Classes::CheckPoint::Firewall1::Component::VpnSubsystem");
+  } elsif ($self->mode =~ /device::vpn::sessions/) {
+    $self->analyze_and_check_config_subsystem("Classes::CheckPoint::Firewall1::Component::VpnSessions");
   } else {
     $self->no_such_mode();
   }

--- a/plugins-scripts/Classes/CheckPoint/Firewall1/Component/VpnSessions.pm
+++ b/plugins-scripts/Classes/CheckPoint/Firewall1/Component/VpnSessions.pm
@@ -1,0 +1,21 @@
+package Classes::CheckPoint::Firewall1::Component::VpnSessions;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my ($self) = @_;
+  $self->get_snmp_objects('CHECKPOINT-MIB', (qw(cpvIKECurrRespSAs cpvIKEMaxConncurRespSAs)));
+}
+
+sub check {
+  my ($self) = @_;
+  $self->add_info(sprintf '%.2f vpn sessions used', $self->{cpvIKECurrRespSAs});
+  $self->set_thresholds(warning => 180, critical => 200);
+  $self->add_message($self->check_thresholds($self->{cpvIKECurrRespSAs}));
+  $self->add_perfdata(
+      label => 'vpn_sessions',
+      value => $self->{cpvIKECurrRespSAs},
+      min => 0,
+      max => $self->{cpvIKEMaxConncurRespSAs},
+  );
+}


### PR DESCRIPTION
This PR adds the possibility to monitor the number of VPN sessions on a Checkpoint FW-1. 
Important to note however: These numbers do not represent VPN users, but rather so called "SAs" (Security Associations). Such SA's are created for VPN users but also for S2S VPN tunnels.
Depending on the Checkpoint configuration, there might be one SA per connected subnet, or one SA for each connected host using a S2S tunnel.
As far as I understand, there are three configuration options in Checkpoint:

- SA per communicating host (most SA's will be created)
- SA per communicating subnet 
- SA per communicating gateway (fewest SA's will be created)

Output will show the SA numbers (here with 800 warning and 1000 critical thresholds):

```
OK - 260.00 vpn sessions used | 'vpn_sessions'=260;800;1000;0;285
```