### PR TITLE
Fix Huawei memory submodule perfdata labels

### DIFF
--- a/plugins-scripts/Classes/Huawei/Component/MemSubsystem.pm
+++ b/plugins-scripts/Classes/Huawei/Component/MemSubsystem.pm
@@ -34,17 +34,17 @@ sub check {
         $self->{name}, $self->{hwEntityMemUsage});
   }
   $self->set_thresholds(
-      metric => 'cpu_'.$self->{name},
+      metric => 'memory_usage_'.$self->{name},
       warning => $self->{hwEntityMemUsageThreshold},
       critical => $self->{hwEntityMemUsageThreshold},
   );
   $self->add_message(
       $self->check_thresholds(
-          metric => 'cpu_'.$self->{name},
+          metric => 'memory_usage_'.$self->{name},
           value => $self->{hwEntityMemUsage}
   ));
   $self->add_perfdata(
-      label => 'cpu_'.$self->{name},
+      label => 'memory_usage_'.$self->{name},
       value => $self->{hwEntityMemUsage},
       uom => '%',
   );


### PR DESCRIPTION
Hi,
The metric name used in perfdatas of Huawei "Memory" subsystem is incorrect.
It should be "memory_usage" rather than "cpu".

Thank you.
Gaël
