### PR TITLE
Fix Use of uninitialized value in numeric gt (>)

### DIFF
--- a/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
+++ b/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
@@ -608,7 +608,7 @@ sub load_interface_cache {
 
 sub make_ifdescr_unique {
   my ($self, $if) = @_;
-  $if->{ifDescr} = $if->{ifDescr}.' '.$if->{flat_indices} if $self->{duplicates}->{$if->{ifDescr}} > 1;
+  $if->{ifDescr} = $if->{ifDescr}.' '.$if->{flat_indices} if defined $self->{duplicates}->{$if->{ifDescr}} && $self->{duplicates}->{$if->{ifDescr}} > 1;
 }
 
 sub get_interface_indices {


### PR DESCRIPTION
Fixes "Use of uninitialized value in numeric gt (>) at /usr/lib/nagios/plugins/check_nwc_health line 70168."

Happens with "interface-usage" of Windows Server 2019 running on KVM.