### PR TITLE
Add "--iflabel" option to select how interface names are found and displayed

### DIFF
--- a/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
+++ b/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
@@ -618,11 +618,23 @@ sub get_interface_indices {
     my $ifDescr = $self->{interface_cache}->{$ifIndex}->{ifDescr};
     my $ifUniqDescr = $self->{interface_cache}->{$ifIndex}->{ifUniqDescr};
     my $ifAlias = $self->{interface_cache}->{$ifIndex}->{ifAlias} || '________';
+    my $ifName = $self->{interface_cache}->{$ifIndex}->{ifName};
+    my @label;
+    if (defined $self->opts->iflabel) {
+      foreach (split ",", $self->opts->iflabel) {
+	next if ($_ !~ m/^(ifName|ifAlias|ifDescr)$/);
+	push @label, ($_ eq 'ifName' ? $ifName :
+		      ($_ eq 'ifAlias' ? $ifAlias :
+		       ($_ eq 'ifDescr' ? $ifDescr : undef)));
+      }
+    }
+    my $iflabel = (scalar @label > 0) ? join("_", @label) : $ifDescr;
+
     # Check ifDescr (using --name)
     if ($self->opts->name) {
       if ($self->opts->regexp) {
         my $pattern = $self->opts->name;
-        if ($ifDescr =~ /$pattern/i) {
+        if ($iflabel =~ /$pattern/i) {
           push(@indices, [$ifIndex]);
         }
       } else {
@@ -631,7 +643,7 @@ sub get_interface_indices {
             push(@indices, [1 * $self->opts->name]);
           }
         } else {
-          if (lc $ifDescr eq lc $self->opts->name) {
+          if (lc $iflabel eq lc $self->opts->name) {
             push(@indices, [$ifIndex]);
           }
         }

--- a/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
+++ b/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
@@ -964,6 +964,16 @@ sub check {
       $self->{ifAlias} && $self->{ifAlias} ne $self->{ifDescr} ?
           " (alias ".$self->{ifAlias}.")" : "",
       $self->{ifAddresses} ? " (addresses ".$self->{ifAddresses}.")" : "";
+
+  my @label;
+  if (defined $self->opts->iflabel) {
+    foreach (split ",", $self->opts->iflabel) {
+      next if ($_ !~ m/^(ifName|ifAlias|ifDescr)$/);
+      push @label, $self->{$_} if defined($self->{$_});
+    }
+  }
+  my $iflabel = (scalar @label > 0) ? join("_", @label) : $self->{ifDescr};
+
   if ($self->mode =~ /device::interfaces::complete/) {
     # uglatto, but $self->mode is an lvalue
     $Monitoring::GLPlugin::mode = "device::interfaces::operstatus";
@@ -987,45 +997,45 @@ sub check {
         sprintf("%.2f%s/s", $self->{outputRate}, $self->opts->units),
         $self->{ifOperStatus} eq 'down' ? ' (down)' : '');
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_usage_in',
+        metric => $iflabel.'_usage_in',
         warning => 80,
         critical => 90
     );
     my $in = $self->check_thresholds(
-        metric => $self->{ifDescr}.'_usage_in',
+        metric => $iflabel.'_usage_in',
         value => $self->{inputUtilization}
     );
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_usage_out',
+        metric => $iflabel.'_usage_out',
         warning => 80,
         critical => 90
     );
     my $out = $self->check_thresholds(
-        metric => $self->{ifDescr}.'_usage_out',
+        metric => $iflabel.'_usage_out',
         value => $self->{outputUtilization}
     );
     my $level = ($in > $out) ? $in : ($out > $in) ? $out : $in;
     $self->add_message($level);
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_usage_in',
+        label => $iflabel.'_usage_in',
         value => $self->{inputUtilization},
         uom => '%',
     );
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_usage_out',
+        label => $iflabel.'_usage_out',
         value => $self->{outputUtilization},
         uom => '%',
     );
     my ($inwarning, $incritical) = $self->get_thresholds(
-        metric => $self->{ifDescr}.'_usage_in',
+        metric => $iflabel.'_usage_in',
     );
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_traffic_in',
+        metric => $iflabel.'_traffic_in',
         warning => $self->{maxInputRate} / 100 * $inwarning,
         critical => $self->{maxInputRate} / 100 * $incritical
     );
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_traffic_in',
+        label => $iflabel.'_traffic_in',
         value => $self->{inputRate},
         uom => $self->opts->units =~ /^(B|KB|MB|GB|TB)$/ ? $self->opts->units : undef,
         places => 2,
@@ -1033,15 +1043,15 @@ sub check {
         max => $self->{maxInputRate},
     );
     my ($outwarning, $outcritical) = $self->get_thresholds(
-        metric => $self->{ifDescr}.'_usage_out',
+        metric => $iflabel.'_usage_out',
     );
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_traffic_out',
+        metric => $iflabel.'_traffic_out',
         warning => $self->{maxOutputRate} / 100 * $outwarning,
         critical => $self->{maxOutputRate} / 100 * $outcritical,
     );
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_traffic_out',
+        label => $iflabel.'_traffic_out',
         value => $self->{outputRate},
         uom => $self->opts->units =~ /^(B|KB|MB|GB|TB)$/ ? $self->opts->units : undef,
         places => 2,
@@ -1053,32 +1063,32 @@ sub check {
         $full_descr,
         $self->{inputErrorsPercent} , $self->{outputErrorsPercent});
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_errors_in',
+        metric => $iflabel.'_errors_in',
         warning => 1,
         critical => 10,
     );
     my $in = $self->check_thresholds(
-        metric => $self->{ifDescr}.'_errors_in',
+        metric => $iflabel.'_errors_in',
         value => $self->{inputErrorsPercent}
     );
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_errors_out',
+        metric => $iflabel.'_errors_out',
         warning => 1,
         critical => 10,
     );
     my $out = $self->check_thresholds(
-        metric => $self->{ifDescr}.'_errors_out',
+        metric => $iflabel.'_errors_out',
         value => $self->{outputErrorsPercent}
     );
     my $level = ($in > $out) ? $in : ($out > $in) ? $out : $in;
     $self->add_message($level);
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_errors_in',
+        label => $iflabel.'_errors_in',
         value => $self->{inputErrorsPercent},
         uom => '%',
     );
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_errors_out',
+        label => $iflabel.'_errors_out',
         value => $self->{outputErrorsPercent},
         uom => '%',
     );
@@ -1087,21 +1097,21 @@ sub check {
         $full_descr,
         $self->{inputDiscardsPercent} , $self->{outputDiscardsPercent});
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_discards_in',
+        metric => $iflabel.'_discards_in',
         warning => 5,
         critical => 10,
     );
     my $in = $self->check_thresholds(
-        metric => $self->{ifDescr}.'_discards_in',
+        metric => $iflabel.'_discards_in',
         value => $self->{inputDiscardsPercent}
     );
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_discards_out',
+        metric => $iflabel.'_discards_out',
         warning => 5,
         critical => 10,
     );
     my $out = $self->check_thresholds(
-        metric => $self->{ifDescr}.'_discards_out',
+        metric => $iflabel.'_discards_out',
         value => $self->{outputDiscardsPercent}
     );
     my $level = ($in > $out) ? $in : ($out > $in) ? $out : $in;
@@ -1132,21 +1142,21 @@ sub check {
         $self->{inputBroadcastPercent} , $self->{outputBroadcastPercent},
         $self->{inputBroadcastUtilizationPercent} , $self->{outputBroadcastUtilizationPercent});
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_broadcast_in',
+        metric => $iflabel.'_broadcast_in',
         warning => 10,
         critical => 20
     );
     my $uin = $self->check_thresholds(
-        metric => $self->{ifDescr}.'_broadcast_in',
+        metric => $iflabel.'_broadcast_in',
         value => $self->{inputBroadcastPercent}
     );
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_broadcast_out',
+        metric => $iflabel.'_broadcast_out',
         warning => 10,
         critical => 20
     );
     my $uout = $self->check_thresholds(
-        metric => $self->{ifDescr}.'_broadcast_out',
+        metric => $iflabel.'_broadcast_out',
         value => $self->{outputBroadcastPercent}
     );
     $self->add_perfdata(
@@ -1161,21 +1171,21 @@ sub check {
     );
     my $ulevel = ($uin > $uout) ? $uin : ($uout > $uin) ? $uout : $uin;
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_broadcast_usage_in',
+        metric => $iflabel.'_broadcast_usage_in',
         warning => 10,
         critical => 20
     );
     my $bin = $self->check_thresholds(
-        metric => $self->{ifDescr}.'_broadcast_usage_in',
+        metric => $iflabel.'_broadcast_usage_in',
         value => $self->{inputBroadcastUtilizationPercent}
     );
     $self->set_thresholds(
-        metric => $self->{ifDescr}.'_broadcast_usage_out',
+        metric => $iflabel.'_broadcast_usage_out',
         warning => 10,
         critical => 20
     );
     my $bout = $self->check_thresholds(
-        metric => $self->{ifDescr}.'_broadcast_usage_out',
+        metric => $iflabel.'_broadcast_usage_out',
         value => $self->{outputBroadcastUtilizationPercent}
     );
     $self->add_perfdata(

--- a/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
+++ b/plugins-scripts/Classes/IFMIB/Component/InterfaceSubsystem.pm
@@ -804,6 +804,16 @@ sub get_mub_pkts {
 
 sub init {
   my ($self) = @_;
+
+  my @label;
+  if (defined $self->opts->iflabel) {
+    foreach (split ",", $self->opts->iflabel) {
+      next if ($_ !~ m/^(ifName|ifAlias|ifDescr)$/);
+      push @label, $self->{$_} if defined($self->{$_});
+    }
+  }
+  $self->{iflabel} = (scalar @label > 0) ? join("_", @label) : $self->{ifDescr};
+
   if ($self->mode =~ /device::interfaces::complete/) {
     # uglatto, but $self->mode is an lvalue
     $Monitoring::GLPlugin::mode = "device::interfaces::operstatus";
@@ -959,20 +969,12 @@ sub init_etherstats {
 
 sub check {
   my ($self) = @_;
+
   my $full_descr = sprintf "%s%s%s",
-      $self->{ifDescr},
-      $self->{ifAlias} && $self->{ifAlias} ne $self->{ifDescr} ?
+      $self->{iflabel},
+      $self->{ifAlias} && $self->{ifAlias} ne $self->{iflabel} ?
           " (alias ".$self->{ifAlias}.")" : "",
       $self->{ifAddresses} ? " (addresses ".$self->{ifAddresses}.")" : "";
-
-  my @label;
-  if (defined $self->opts->iflabel) {
-    foreach (split ",", $self->opts->iflabel) {
-      next if ($_ !~ m/^(ifName|ifAlias|ifDescr)$/);
-      push @label, $self->{$_} if defined($self->{$_});
-    }
-  }
-  my $iflabel = (scalar @label > 0) ? join("_", @label) : $self->{ifDescr};
 
   if ($self->mode =~ /device::interfaces::complete/) {
     # uglatto, but $self->mode is an lvalue
@@ -997,45 +999,45 @@ sub check {
         sprintf("%.2f%s/s", $self->{outputRate}, $self->opts->units),
         $self->{ifOperStatus} eq 'down' ? ' (down)' : '');
     $self->set_thresholds(
-        metric => $iflabel.'_usage_in',
+        metric => $self->{ifDescr}.'_usage_in',
         warning => 80,
         critical => 90
     );
     my $in = $self->check_thresholds(
-        metric => $iflabel.'_usage_in',
+        metric => $self->{ifDescr}.'_usage_in',
         value => $self->{inputUtilization}
     );
     $self->set_thresholds(
-        metric => $iflabel.'_usage_out',
+        metric => $self->{ifDescr}.'_usage_out',
         warning => 80,
         critical => 90
     );
     my $out = $self->check_thresholds(
-        metric => $iflabel.'_usage_out',
+        metric => $self->{ifDescr}.'_usage_out',
         value => $self->{outputUtilization}
     );
     my $level = ($in > $out) ? $in : ($out > $in) ? $out : $in;
     $self->add_message($level);
     $self->add_perfdata(
-        label => $iflabel.'_usage_in',
+        label => $self->{iflabel}.'_usage_in',
         value => $self->{inputUtilization},
         uom => '%',
     );
     $self->add_perfdata(
-        label => $iflabel.'_usage_out',
+        label => $self->{iflabel}.'_usage_out',
         value => $self->{outputUtilization},
         uom => '%',
     );
     my ($inwarning, $incritical) = $self->get_thresholds(
-        metric => $iflabel.'_usage_in',
+        metric => $self->{ifDescr}.'_usage_in',
     );
     $self->set_thresholds(
-        metric => $iflabel.'_traffic_in',
+        metric => $self->{ifDescr}.'_traffic_in',
         warning => $self->{maxInputRate} / 100 * $inwarning,
         critical => $self->{maxInputRate} / 100 * $incritical
     );
     $self->add_perfdata(
-        label => $iflabel.'_traffic_in',
+        label => $self->{iflabel}.'_traffic_in',
         value => $self->{inputRate},
         uom => $self->opts->units =~ /^(B|KB|MB|GB|TB)$/ ? $self->opts->units : undef,
         places => 2,
@@ -1043,15 +1045,15 @@ sub check {
         max => $self->{maxInputRate},
     );
     my ($outwarning, $outcritical) = $self->get_thresholds(
-        metric => $iflabel.'_usage_out',
+        metric => $self->{ifDescr}.'_usage_out',
     );
     $self->set_thresholds(
-        metric => $iflabel.'_traffic_out',
+        metric => $self->{ifDescr}.'_traffic_out',
         warning => $self->{maxOutputRate} / 100 * $outwarning,
         critical => $self->{maxOutputRate} / 100 * $outcritical,
     );
     $self->add_perfdata(
-        label => $iflabel.'_traffic_out',
+        label => $self->{iflabel}.'_traffic_out',
         value => $self->{outputRate},
         uom => $self->opts->units =~ /^(B|KB|MB|GB|TB)$/ ? $self->opts->units : undef,
         places => 2,
@@ -1063,32 +1065,32 @@ sub check {
         $full_descr,
         $self->{inputErrorsPercent} , $self->{outputErrorsPercent});
     $self->set_thresholds(
-        metric => $iflabel.'_errors_in',
+        metric => $self->{ifDescr}.'_errors_in',
         warning => 1,
         critical => 10,
     );
     my $in = $self->check_thresholds(
-        metric => $iflabel.'_errors_in',
+        metric => $self->{ifDescr}.'_errors_in',
         value => $self->{inputErrorsPercent}
     );
     $self->set_thresholds(
-        metric => $iflabel.'_errors_out',
+        metric => $self->{ifDescr}.'_errors_out',
         warning => 1,
         critical => 10,
     );
     my $out = $self->check_thresholds(
-        metric => $iflabel.'_errors_out',
+        metric => $self->{ifDescr}.'_errors_out',
         value => $self->{outputErrorsPercent}
     );
     my $level = ($in > $out) ? $in : ($out > $in) ? $out : $in;
     $self->add_message($level);
     $self->add_perfdata(
-        label => $iflabel.'_errors_in',
+        label => $self->{iflabel}.'_errors_in',
         value => $self->{inputErrorsPercent},
         uom => '%',
     );
     $self->add_perfdata(
-        label => $iflabel.'_errors_out',
+        label => $self->{iflabel}.'_errors_out',
         value => $self->{outputErrorsPercent},
         uom => '%',
     );
@@ -1097,32 +1099,32 @@ sub check {
         $full_descr,
         $self->{inputDiscardsPercent} , $self->{outputDiscardsPercent});
     $self->set_thresholds(
-        metric => $iflabel.'_discards_in',
+        metric => $self->{ifDescr}.'_discards_in',
         warning => 5,
         critical => 10,
     );
     my $in = $self->check_thresholds(
-        metric => $iflabel.'_discards_in',
+        metric => $self->{ifDescr}.'_discards_in',
         value => $self->{inputDiscardsPercent}
     );
     $self->set_thresholds(
-        metric => $iflabel.'_discards_out',
+        metric => $self->{ifDescr}.'_discards_out',
         warning => 5,
         critical => 10,
     );
     my $out = $self->check_thresholds(
-        metric => $iflabel.'_discards_out',
+        metric => $self->{ifDescr}.'_discards_out',
         value => $self->{outputDiscardsPercent}
     );
     my $level = ($in > $out) ? $in : ($out > $in) ? $out : $in;
     $self->add_message($level);
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_discards_in',
+        label => $self->{iflabel}.'_discards_in',
         value => $self->{inputDiscardsPercent},
         uom => '%',
     );
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_discards_out',
+        label => $self->{iflabel}.'_discards_out',
         value => $self->{outputDiscardsPercent},
         uom => '%',
     );
@@ -1142,59 +1144,59 @@ sub check {
         $self->{inputBroadcastPercent} , $self->{outputBroadcastPercent},
         $self->{inputBroadcastUtilizationPercent} , $self->{outputBroadcastUtilizationPercent});
     $self->set_thresholds(
-        metric => $iflabel.'_broadcast_in',
+        metric => $self->{ifDescr}.'_broadcast_in',
         warning => 10,
         critical => 20
     );
     my $uin = $self->check_thresholds(
-        metric => $iflabel.'_broadcast_in',
+        metric => $self->{ifDescr}.'_broadcast_in',
         value => $self->{inputBroadcastPercent}
     );
     $self->set_thresholds(
-        metric => $iflabel.'_broadcast_out',
+        metric => $self->{ifDescr}.'_broadcast_out',
         warning => 10,
         critical => 20
     );
     my $uout = $self->check_thresholds(
-        metric => $iflabel.'_broadcast_out',
+        metric => $self->{ifDescr}.'_broadcast_out',
         value => $self->{outputBroadcastPercent}
     );
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_broadcast_in',
+        label => $self->{iflabel}.'_broadcast_in',
         value => $self->{inputBroadcastPercent},
         uom => '%',
     );
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_broadcast_out',
+        label => $self->{iflabel}.'_broadcast_out',
         value => $self->{outputBroadcastPercent},
         uom => '%',
     );
     my $ulevel = ($uin > $uout) ? $uin : ($uout > $uin) ? $uout : $uin;
     $self->set_thresholds(
-        metric => $iflabel.'_broadcast_usage_in',
+        metric => $self->{ifDescr}.'_broadcast_usage_in',
         warning => 10,
         critical => 20
     );
     my $bin = $self->check_thresholds(
-        metric => $iflabel.'_broadcast_usage_in',
+        metric => $self->{ifDescr}.'_broadcast_usage_in',
         value => $self->{inputBroadcastUtilizationPercent}
     );
     $self->set_thresholds(
-        metric => $iflabel.'_broadcast_usage_out',
+        metric => $self->{ifDescr}.'_broadcast_usage_out',
         warning => 10,
         critical => 20
     );
     my $bout = $self->check_thresholds(
-        metric => $iflabel.'_broadcast_usage_out',
+        metric => $self->{ifDescr}.'_broadcast_usage_out',
         value => $self->{outputBroadcastUtilizationPercent}
     );
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_broadcast_usage_in',
+        label => $self->{iflabel}.'_broadcast_usage_in',
         value => $self->{inputBroadcastUtilizationPercent},
         uom => '%',
     );
     $self->add_perfdata(
-        label => $self->{ifDescr}.'_broadcast_usage_out',
+        label => $self->{iflabel}.'_broadcast_usage_out',
         value => $self->{outputBroadcastUtilizationPercent},
         uom => '%',
     );
@@ -1239,7 +1241,7 @@ sub check {
     $self->{ifStatusDuration} = 
         $self->human_timeticks($self->{ifStatusDuration});
     $self->add_info(sprintf '%s is %savailable (%s/%s, since %s)',
-        $self->{ifDescr}, ($self->{ifAvailable} eq "true" ? "" : "un"),
+        $self->{iflabel}, ($self->{ifAvailable} eq "true" ? "" : "un"),
         $self->{ifOperStatus}, $self->{ifAdminStatus},
         $self->{ifStatusDuration});
   } elsif ($self->mode =~ /device::interfaces::etherstats/) {
@@ -1248,7 +1250,7 @@ sub check {
       my $label = $stat.'Percent';
       $label =~ s/^(dot3Stats|etherStats)//g;
       $label =~ s/(?:\b|(?<=([a-z])))([A-Z][a-z]+)/(defined($1) ? "_" : "") . lc($2)/eg;
-      $label = $self->{ifDescr}.'_'.$label;
+      $label = $self->{iflabel}.'_'.$label;
       $self->add_info(sprintf 'interface %s %s is %.2f%%',
           $full_descr, $stat.'Percent', $self->{$stat.'Percent'});
       $self->set_thresholds(
@@ -1266,7 +1268,7 @@ sub check {
     }
   } elsif ($self->mode =~ /device::interfaces::duplex/) {
     $self->add_info(sprintf "%s duplex status is %s",
-        $self->{ifDescr}, $self->{dot3StatsDuplexStatus}
+        $self->{iflabel}, $self->{dot3StatsDuplexStatus}
     );
     if ($self->{ifOperStatus} ne "up") {
       $self->annotate_info(sprintf "oper %s", $self->{ifOperStatus});
@@ -1292,7 +1294,7 @@ sub check {
         metric => $self->{ifDescr}."_duration",
         value => $self->{ifDurationMinutes}));
     $self->add_perfdata(
-        label => $self->{ifDescr}."_duration",
+        label => $self->{iflabel}."_duration",
         value => $self->{ifDurationMinutes},
     );
   }
@@ -1303,10 +1305,10 @@ sub list {
   if ($self->mode =~ /device::interfaces::listdetail/) {
     my $cL2L3IfModeOper = $self->get_snmp_object('CISCO-L2L3-INTERFACE-CONFIG-MIB', 'cL2L3IfModeOper', $self->{ifIndex}) || "unknown";
     my $vlanTrunkPortDynamicStatus = $self->get_snmp_object('CISCO-VTP-MIB', 'vlanTrunkPortDynamicStatus', $self->{ifIndex}) || "unknown";
-    printf "%06d %s %s %s %s\n", $self->{ifIndex}, $self->{ifDescr}, $self->{ifAlias},
+    printf "%06d %s %s %s %s\n", $self->{ifIndex}, $self->{iflabel}, $self->{ifAlias},
         $cL2L3IfModeOper, $vlanTrunkPortDynamicStatus;
   } else {
-    printf "%06d %s\n", $self->{ifIndex}, $self->{ifDescr};
+    printf "%06d %s\n", $self->{ifIndex}, $self->{iflabel};
   }
 }
 
@@ -1395,6 +1397,16 @@ sub get_mub_pkts {
 
 sub init {
   my ($self) = @_;
+
+  my @label;
+  if (defined $self->opts->iflabel) {
+    foreach (split ",", $self->opts->iflabel) {
+      next if ($_ !~ m/^(ifName|ifAlias|ifDescr)$/);
+      push @label, $self->{$_} if defined($self->{$_});
+    }
+  }
+  $self->{iflabel} = (scalar @label > 0) ? join("_", @label) : $self->{ifDescr};
+
   if ($self->mode =~ /device::interfaces::usage/) {
     $self->calc_usage();
   } elsif ($self->mode =~ /device::interfaces::broadcasts/) {
@@ -1458,7 +1470,7 @@ sub init_etherstats {
 sub check {
   my ($self) = @_;
   my $full_descr = sprintf "%s%s%s",
-      $self->{ifDescr},
+      $self->{iflabel},
       $self->{ifAlias} && $self->{ifAlias} ne $self->{ifDescr} ?
           " (alias ".$self->{ifAlias}.")" : "",
       $self->{ifAddresses} ? " (addresses ".$self->{ifAddresses}.")" : "";

--- a/plugins-scripts/check_nwc_health.pl
+++ b/plugins-scripts/check_nwc_health.pl
@@ -589,6 +589,14 @@ $plugin->add_arg(
     required => 0,
 );
 $plugin->add_arg(
+    spec => 'iflabel=s',
+    help => "--iflabel
+   Interface Label for perfdata. Can be any combination of ifDescr, ifName or ifAlias seperated by Comma.
+   Example: ifName,ifAlias
+   Default: ifDescr",
+    required => 0,
+);
+$plugin->add_arg(
     spec => 'role=s',
     help => "--role
    The role of this device in a hsrp group (active/standby/listen)",


### PR DESCRIPTION
This is based on PR #111 and should solve #254 and other problems with newer net-snmp implementations.

The new "--iflabel" options decides which of ifDescr, ifName and ifAlias is used as the label for the interface, and also sets that field to be used to filter with --name.