### PR TITLE
Blacklist storage device "junosprocfs" on JunOS (Juniper) devices

### DIFF
--- a/plugins-scripts/Classes/Juniper/SRX.pm
+++ b/plugins-scripts/Classes/Juniper/SRX.pm
@@ -10,7 +10,7 @@ sub init {
     $self->{components}->{hostresource_subsystem} =
         Classes::HOSTRESOURCESMIB::Component::EnvironmentalSubsystem->new();
     foreach (@{$self->{components}->{hostresource_subsystem}->{disk_subsystem}->{storages}}) {
-      if (exists $_->{device} && $_->{device} =~ /^\/dev\/md/) {
+      if (exists $_->{device} && $_->{device} =~ /^(\/dev\/md|junosprocfs)/) {
         $_->blacklist();
       }
     }


### PR DESCRIPTION
Juniper systems (switches/routers/firewalls...) running JunOS 15.1 or later have a virtual filesystem of type "junosprocfs" which is always 100% utilized. This pull request automatically blacklists such storage devices and saves users from having to maintain additional "STORAGE:xyz" blacklist configurations on a per-host basis.

See https://kb.juniper.net/InfoCenter/index?page=content&id=KB33032&cat=MX240_1&actp=LIST for reference.