### PR TITLE
cisco: if fru mib is implemented, also check sensors

### DIFF
--- a/plugins-scripts/Classes/Cisco/IOS/Component/EnvironmentalSubsystem.pm
+++ b/plugins-scripts/Classes/Cisco/IOS/Component/EnvironmentalSubsystem.pm
@@ -42,6 +42,12 @@ sub init {
   } elsif ($self->implements_mib('CISCO-ENTITY-FRU-CONTROL-MIB')) {
     $self->{fru_subsystem} =
         Classes::Cisco::CISCOENTITYFRUCONTROLMIB::Component::EnvironmentalSubsystem->new();
+    # FRU MIBS doesn't show temperature sensors, only module status, etc.
+    # checking sensors is nice to show that your datacenter is too warm ...
+    if ($self->implements_mib('CISCO-ENTITY-SENSOR-MIB')) {
+        $self->{sensor_subsystem} =
+            Classes::Cisco::CISCOENTITYSENSORMIB::Component::SensorSubsystem->new();
+    }
   } elsif ($self->implements_mib('CISCO-ENTITY-SENSOR-MIB')) {
     # (IOS can have ENVMON+ENTITY. Sensors are copies, so not needed)
     $self->{sensor_subsystem} =


### PR DESCRIPTION
I know you won't accept my PR anymore. Well, it would be nice if you could take a look at it.

In this case. IOS-XE on Cisco 4331 supports both. The CISCO-ENTITY-FRU-CONTROL-MIB and the CISCO-ENTITY-SENSOR-MIB mib. The Control Mib only reports the status of the swapable modules like fan try or power supply, but nothing more. When we also query the sensors mib that would give us access to all the others sensors like temperature, fan speed, voltages, watt usages, etc.

Maybe another combination of checking supported env mibs could make sense to avoid code duplication. That's up to you.

Thanks