### PR TITLE
Support TP-Link devices for cpu/memory monitoring

### DIFF
--- a/plugins-scripts/CheckNwcHealth/Device.pm
+++ b/plugins-scripts/CheckNwcHealth/Device.pm
@@ -205,7 +205,7 @@ sub classify {
         $self->rebless('CheckNwcHealth::Versa');
       } elsif ($self->implements_mib('SKYHIGHSECURITY-SWG-MIB') and $self->{productname} =~ /Skyhigh Secure Web Gateway/) {
         $self->rebless('CheckNwcHealth::SkyHigh');
-      } elsif ($self->{productname} =~ /JetStream/i || $self->implements_mib('TPLINK-MIB')) {
+      } elsif ($self->{productname} =~ /JetStream/i || $self->implements_mib('TPLINK-SYSINFO-MIB')) {
         $self->rebless('CheckNwcHealth::TPLink');
       } elsif ($self->{productname} =~ /^Linux/i) {
         $self->rebless('CheckNwcHealth::Server::Linux');

--- a/plugins-scripts/CheckNwcHealth/Device.pm
+++ b/plugins-scripts/CheckNwcHealth/Device.pm
@@ -205,6 +205,8 @@ sub classify {
         $self->rebless('CheckNwcHealth::Versa');
       } elsif ($self->implements_mib('SKYHIGHSECURITY-SWG-MIB') and $self->{productname} =~ /Skyhigh Secure Web Gateway/) {
         $self->rebless('CheckNwcHealth::SkyHigh');
+      } elsif ($self->{productname} =~ /JetStream/i || $self->implements_mib('TPLINK-MIB')) {
+        $self->rebless('CheckNwcHealth::TPLink');
       } elsif ($self->{productname} =~ /^Linux/i) {
         $self->rebless('CheckNwcHealth::Server::Linux');
       } else {

--- a/plugins-scripts/CheckNwcHealth/TPLink.pm
+++ b/plugins-scripts/CheckNwcHealth/TPLink.pm
@@ -1,0 +1,50 @@
+#package CheckNwcHealth::TPLink;
+#our @ISA = qw(CheckNwcHealth::Device);
+#use strict;
+#
+#use constant trees => (
+#    '1.3.6.1.4.1.11863', # TPLINK-MIB
+#);
+#
+#sub init {
+#  my ($self) = @_;
+#  if ($self->get_snmp_object('TPLINK-MIB', 'tpSysInfoDescription') && $self->get_snmp_object('TPLINK-MIB', 'tpSysInfoDescription') =~ /JetStream/i) {
+#    bless $self, 'CheckNwcHealth::TPLink';
+#    $self->debug('using CheckNwcHealth::TPLink');
+#  } else {
+#    $self->no_such_model();
+#  }
+#  if (ref($self) ne "CheckNwcHealth::TPLink") {
+#    $self->init();
+#  } else {
+#    if ($self->mode =~ /device::hardware::load/) {
+#      $self->analyze_and_check_cpu_subsystem("CheckNwcHealth::TPLink::Component::CpuSubsystem");
+#    } elsif ($self->mode =~ /device::hardware::memory/) {
+#      $self->analyze_and_check_mem_subsystem("CheckNwcHealth::TPLink::Component::MemSubsystem");
+#    }
+#  }
+#}
+#
+
+package CheckNwcHealth::TPLink;
+our @ISA = qw(CheckNwcHealth::Device);
+use strict;
+
+sub init {
+  my ($self) = @_;
+  if ($self->get_snmp_object('TPLINK-MIB', 'tpSysInfoDescription') && $self->get_snmp_object('TPLINK-MIB', 'tpSysInfoDescription') =~ /JetStream/i) {
+    bless $self, 'CheckNwcHealth::TPLink';
+    $self->debug('using CheckNwcHealth::TPLink');
+  }
+  if (ref($self) ne "CheckNwcHealth::TPLink") {
+    $self->init();
+  } else {
+    if ($self->mode =~ /device::hardware::load/) {
+      $self->analyze_and_check_cpu_subsystem("CheckNwcHealth::TPLink::Component::CpuSubsystem");
+    } elsif ($self->mode =~ /device::hardware::memory/) {
+      $self->analyze_and_check_mem_subsystem("CheckNwcHealth::TPLink::Component::MemSubsystem");
+    } else {
+      $self->no_such_mode();
+    }
+  }
+}

--- a/plugins-scripts/CheckNwcHealth/TPLink.pm
+++ b/plugins-scripts/CheckNwcHealth/TPLink.pm
@@ -4,7 +4,7 @@ use strict;
 
 sub init {
   my ($self) = @_;
-  if ($self->get_snmp_object('TPLINK-MIB', 'tpSysInfoDescription') && $self->get_snmp_object('TPLINK-MIB', 'tpSysInfoDescription') =~ /JetStream/i) {
+  if ($self->get_snmp_object('TPLINK-SYSINFO-MIB', 'tpSysInfoDescription') && $self->get_snmp_object('TPLINK-SYSINFO-MIB', 'tpSysInfoDescription') =~ /JetStream/i) {
     bless $self, 'CheckNwcHealth::TPLink';
     $self->debug('using CheckNwcHealth::TPLink');
   }

--- a/plugins-scripts/CheckNwcHealth/TPLink.pm
+++ b/plugins-scripts/CheckNwcHealth/TPLink.pm
@@ -1,31 +1,3 @@
-#package CheckNwcHealth::TPLink;
-#our @ISA = qw(CheckNwcHealth::Device);
-#use strict;
-#
-#use constant trees => (
-#    '1.3.6.1.4.1.11863', # TPLINK-MIB
-#);
-#
-#sub init {
-#  my ($self) = @_;
-#  if ($self->get_snmp_object('TPLINK-MIB', 'tpSysInfoDescription') && $self->get_snmp_object('TPLINK-MIB', 'tpSysInfoDescription') =~ /JetStream/i) {
-#    bless $self, 'CheckNwcHealth::TPLink';
-#    $self->debug('using CheckNwcHealth::TPLink');
-#  } else {
-#    $self->no_such_model();
-#  }
-#  if (ref($self) ne "CheckNwcHealth::TPLink") {
-#    $self->init();
-#  } else {
-#    if ($self->mode =~ /device::hardware::load/) {
-#      $self->analyze_and_check_cpu_subsystem("CheckNwcHealth::TPLink::Component::CpuSubsystem");
-#    } elsif ($self->mode =~ /device::hardware::memory/) {
-#      $self->analyze_and_check_mem_subsystem("CheckNwcHealth::TPLink::Component::MemSubsystem");
-#    }
-#  }
-#}
-#
-
 package CheckNwcHealth::TPLink;
 our @ISA = qw(CheckNwcHealth::Device);
 use strict;

--- a/plugins-scripts/CheckNwcHealth/TPLink/Component/CpuSubsystem.pm
+++ b/plugins-scripts/CheckNwcHealth/TPLink/Component/CpuSubsystem.pm
@@ -4,7 +4,7 @@ use strict;
 
 sub init {
   my ($self) = @_;
-  $self->get_snmp_tables('TPLINK-MIB', [
+  $self->get_snmp_tables('TPLINK-SYSMONITOR-MIB', [
     ['tpSysMonitorCpu', 'tpSysMonitorCpuTable', 'CheckNwcHealth::TPLink::Component::CpuSubsystem::Device' ],
   ]);
 }

--- a/plugins-scripts/CheckNwcHealth/TPLink/Component/CpuSubsystem.pm
+++ b/plugins-scripts/CheckNwcHealth/TPLink/Component/CpuSubsystem.pm
@@ -1,0 +1,31 @@
+package CheckNwcHealth::TPLink::Component::CpuSubsystem;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my ($self) = @_;
+  $self->get_snmp_tables('TPLINK-MIB', [
+    ['tpSysMonitorCpu', 'tpSysMonitorCpuTable', 'CheckNwcHealth::TPLink::Component::CpuSubsystem::Device' ],
+  ]);
+}
+
+
+package CheckNwcHealth::TPLink::Component::CpuSubsystem::Device;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::TableItem);
+use strict;
+
+sub check {
+  my ($self) = @_;
+  my $label = sprintf('cpu_%s_usage', $self->{flat_indices});
+  $self->add_info(sprintf 'cpu_%s usage is %.2f%%',
+      $self->{flat_indices}, $self->{tpSysMonitorCpu5Seconds});
+  $self->set_thresholds(metric => $label, warning => 80, critical => 90);
+  $self->add_message($self->check_thresholds(
+      metric => $label, value => $self->{tpSysMonitorCpu5Seconds}));
+  $self->add_perfdata(
+      label => $label,
+      value => $self->{tpSysMonitorCpu5Seconds},
+      uom => '%',
+  );
+}
+

--- a/plugins-scripts/CheckNwcHealth/TPLink/Component/MemSubsystem.pm
+++ b/plugins-scripts/CheckNwcHealth/TPLink/Component/MemSubsystem.pm
@@ -4,7 +4,7 @@ use strict;
 
 sub init {
   my ($self) = @_;
-  $self->get_snmp_tables('TPLINK-MIB', [
+  $self->get_snmp_tables('TPLINK-SYSMONITOR-MIB', [
     ['tpSysMonitorMemory', 'tpSysMonitorMemoryTable', 'CheckNwcHealth::TPLink::Component::MemSubsystem::Device' ],
   ]);
 }

--- a/plugins-scripts/CheckNwcHealth/TPLink/Component/MemSubsystem.pm
+++ b/plugins-scripts/CheckNwcHealth/TPLink/Component/MemSubsystem.pm
@@ -1,0 +1,30 @@
+package CheckNwcHealth::TPLink::Component::MemSubsystem;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::Item);
+use strict;
+
+sub init {
+  my ($self) = @_;
+  $self->get_snmp_tables('TPLINK-MIB', [
+    ['tpSysMonitorMemory', 'tpSysMonitorMemoryTable', 'CheckNwcHealth::TPLink::Component::MemSubsystem::Device' ],
+  ]);
+}
+
+
+package CheckNwcHealth::TPLink::Component::MemSubsystem::Device;
+our @ISA = qw(Monitoring::GLPlugin::SNMP::TableItem);
+use strict;
+
+sub check {
+  my ($self) = @_;
+  my $label = sprintf('memory_%s_usage', $self->{flat_indices});
+  $self->add_info(sprintf 'memory_%s usage is %.2f%%',
+      $self->{flat_indices}, $self->{tpSysMonitorMemoryUtilization});
+  $self->set_thresholds(metric => $label, warning => 80, critical => 90);
+  $self->add_message($self->check_thresholds(
+      metric => $label, value => $self->{tpSysMonitorMemoryUtilization}));
+  $self->add_perfdata(
+      label => $label,
+      value => $self->{tpSysMonitorMemoryUtilization},
+      uom => '%',
+  );
+}

--- a/plugins-scripts/Makefile.am
+++ b/plugins-scripts/Makefile.am
@@ -180,6 +180,7 @@ GL_MODULES=\
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/SWMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/SYNOPTICSROOTMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/SYSTEMRESOURCESMIB.pm \
+  ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/TPLINKMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/UCDDISKIOMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/UCDSNMPMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/USAGEMIB.pm \
@@ -570,6 +571,9 @@ EXTRA_MODULES=\
   CheckNwcHealth/PulseSecure/Gateway.pm \
   CheckNwcHealth/SkyHigh/SWG.pm \
   CheckNwcHealth/SkyHigh.pm \
+  CheckNwcHealth/TPLink/Component/MemSubsystem.pm \
+  CheckNwcHealth/TPLink/Component/CpuSubsystem.pm \
+  CheckNwcHealth/TPLink.pm \
   CheckNwcHealth/INTELSERVERBASEBOARD7/Component/EnvironmntalSubsystem.pm \
   CheckNwcHealth/Device.pm
 

--- a/plugins-scripts/Makefile.am
+++ b/plugins-scripts/Makefile.am
@@ -180,7 +180,8 @@ GL_MODULES=\
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/SWMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/SYNOPTICSROOTMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/SYSTEMRESOURCESMIB.pm \
-  ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/TPLINKMIB.pm \
+  ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/TPLINKSYSINFOMIB.pm \
+  ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/TPLINKSYSMONITORMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/UCDDISKIOMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/UCDSNMPMIB.pm \
   ../GLPlugin/lib/Monitoring/GLPlugin/SNMP/MibsAndOids/USAGEMIB.pm \


### PR DESCRIPTION
This PR adds support for TP-Link devices.
I have successfully tested this on a managed TP-Link switch, model TL-SG2428P. 

CPU Usage:

```
$ ./plugins-scripts/check_nwc_health --hostname tplink --community public --mode cpu-usage
OK - cpu_1 usage is 19.00% | 'cpu_1_usage'=19%;80;90;0;100
```

Memory Usage:

```
$ ./plugins-scripts/check_nwc_health --hostname tplink --community public --mode memory-usage
OK - memory_1 usage is 38.00% | 'memory_1_usage'=38%;80;90;0;100
```

This PR also depends on https://github.com/lausser/GLPlugin/pull/34