### PR TITLE
Cisco power monitoring fixes

### DIFF
--- a/plugins-scripts/CheckNwcHealth/Cisco/CISCOENVMONMIB/Component/PowersupplySubsystem.pm
+++ b/plugins-scripts/CheckNwcHealth/Cisco/CISCOENVMONMIB/Component/PowersupplySubsystem.pm
@@ -36,6 +36,9 @@ sub check {
     $self->add_critical();
   } elsif ($self->{ciscoEnvMonSupplyState} ne 'normal') {
     $self->add_critical();
+  } elsif ($self->{ciscoEnvMonSupplyStatusDescr} =~
+      /Sw\d+, PS\d+ Normal, RPS Critical/) {
+    $self->add_warning();
   }
 }
 

--- a/plugins-scripts/CheckNwcHealth/Cisco/CISCOENVMONMIB/Component/PowersupplySubsystem.pm
+++ b/plugins-scripts/CheckNwcHealth/Cisco/CISCOENVMONMIB/Component/PowersupplySubsystem.pm
@@ -24,16 +24,6 @@ sub check {
   if ($self->{ciscoEnvMonSupplyState} eq 'notPresent') {
   } elsif ($self->{ciscoEnvMonSupplyState} eq 'warning') {
     $self->add_warning();
-  } elsif ($self->{ciscoEnvMonSupplyState} eq 'critical' &&
-      $self->{ciscoEnvMonSupplyStatusDescr} =~
-      /Sw\d+, PS\d+ Critical, RPS Normal/) {
-    # 4.8.2017:
-    # Der Netzwerktechniker on site sagt mir, dass das aber so normal ist,
-    # weil die Netzteile nicht angeschlossen sind, und der switch
-    # nur ueber "RPS" seinen Saft bezieht. Gut ich kenn mich mit dem Geraffel
-    # nicht aus, also glaube ich ihm das mal.
-    # Gruesse, aus dem gerade extrem heissen Athen.
-    $self->add_ok();
   } elsif ($self->{ciscoEnvMonSupplyState} eq 'shutdown' &&
       $self->{ciscoEnvMonSupplySource} eq 'ac') {
     # check for bug


### PR DESCRIPTION
This pull request fixes a couple of Cisco power supply monitoring issues, related to external RPS (redundant power supply) units.