### PR TITLE
Fix interface error/discard percentage calculation exceeding 100%

### DIFF
--- a/plugins-scripts/CheckNwcHealth/IFMIB/Component/InterfaceSubsystem.pm
+++ b/plugins-scripts/CheckNwcHealth/IFMIB/Component/InterfaceSubsystem.pm
@@ -977,9 +977,9 @@ sub init {
     $self->get_mub_pkts() if ! defined $self->{delta_ifOutPkts};
     $self->valdiff({name => $self->{ifDescr}}, qw(ifInErrors ifOutErrors));
     $self->{inputErrorsPercent} = $self->{delta_ifInPkts} == 0 ? 0 :
-        100 * $self->{delta_ifInErrors} / $self->{delta_ifInPkts};
+        100 * $self->{delta_ifInErrors} / ($self->{delta_ifInPkts} + $self->{delta_ifInErrors});
     $self->{outputErrorsPercent} = $self->{delta_ifOutPkts} == 0 ? 0 :
-        100 * $self->{delta_ifOutErrors} / $self->{delta_ifOutPkts};
+        100 * $self->{delta_ifOutErrors} / ($self->{delta_ifOutPkts} + $self->{delta_ifOutErrors});
     $self->{inputErrorRate} = $self->{delta_ifInErrors} 
         / $self->{delta_timestamp};
     $self->{outputErrorRate} = $self->{delta_ifOutErrors} 
@@ -989,9 +989,9 @@ sub init {
     $self->get_mub_pkts() if ! defined $self->{delta_ifOutPkts};
     $self->valdiff({name => $self->{ifDescr}}, qw(ifInDiscards ifOutDiscards));
     $self->{inputDiscardsPercent} = $self->{delta_ifInPkts} == 0 ? 0 :
-        100 * $self->{delta_ifInDiscards} / $self->{delta_ifInPkts};
+        100 * $self->{delta_ifInDiscards} / ($self->{delta_ifInPkts} + $self->{delta_ifInDiscards});
     $self->{outputDiscardsPercent} = $self->{delta_ifOutPkts} == 0 ? 0 :
-        100 * $self->{delta_ifOutDiscards} / $self->{delta_ifOutPkts};
+        100 * $self->{delta_ifOutDiscards} / ($self->{delta_ifOutPkts} + $self->{delta_ifOutDiscards});
     $self->{inputDiscardRate} = $self->{delta_ifInDiscards} 
         / $self->{delta_timestamp};
     $self->{outputDiscardRate} = $self->{delta_ifOutDiscards} 

--- a/plugins-scripts/CheckNwcHealth/IFMIB/Component/InterfaceSubsystem.pm
+++ b/plugins-scripts/CheckNwcHealth/IFMIB/Component/InterfaceSubsystem.pm
@@ -976,10 +976,12 @@ sub init {
     $self->calc_usage() if ! defined $self->{inputUtilization};
     $self->get_mub_pkts() if ! defined $self->{delta_ifOutPkts};
     $self->valdiff({name => $self->{ifDescr}}, qw(ifInErrors ifOutErrors));
-    $self->{inputErrorsPercent} = $self->{delta_ifInPkts} == 0 ? 0 :
-        100 * $self->{delta_ifInErrors} / ($self->{delta_ifInPkts} + $self->{delta_ifInErrors});
-    $self->{outputErrorsPercent} = $self->{delta_ifOutPkts} == 0 ? 0 :
-        100 * $self->{delta_ifOutErrors} / ($self->{delta_ifOutPkts} + $self->{delta_ifOutErrors});
+    my $totalInPkts = $self->{delta_ifInPkts} + $self->{delta_ifInErrors} + $self->{delta_ifInDiscards};
+    $self->{inputErrorsPercent} = $totalInPkts == 0 ? 0 :
+        100 * $self->{delta_ifInErrors} / $totalInPkts;
+    my $totalOutPkts = $self->{delta_ifOutPkts} + $self->{delta_ifOutErrors} + $self->{delta_ifOutDiscards};
+    $self->{outputErrorsPercent} = $totalOutPkts == 0 ? 0 :
+        100 * $self->{delta_ifOutErrors} / $totalOutPkts;
     $self->{inputErrorRate} = $self->{delta_ifInErrors} 
         / $self->{delta_timestamp};
     $self->{outputErrorRate} = $self->{delta_ifOutErrors} 
@@ -988,10 +990,12 @@ sub init {
     $self->calc_usage() if ! defined $self->{inputUtilization};
     $self->get_mub_pkts() if ! defined $self->{delta_ifOutPkts};
     $self->valdiff({name => $self->{ifDescr}}, qw(ifInDiscards ifOutDiscards));
-    $self->{inputDiscardsPercent} = $self->{delta_ifInPkts} == 0 ? 0 :
-        100 * $self->{delta_ifInDiscards} / ($self->{delta_ifInPkts} + $self->{delta_ifInDiscards});
-    $self->{outputDiscardsPercent} = $self->{delta_ifOutPkts} == 0 ? 0 :
-        100 * $self->{delta_ifOutDiscards} / ($self->{delta_ifOutPkts} + $self->{delta_ifOutDiscards});
+    my $totalInPkts = $self->{delta_ifInPkts} + $self->{delta_ifInErrors} + $self->{delta_ifInDiscards};
+    $self->{inputDiscardsPercent} = $totalInPkts == 0 ? 0 :
+        100 * $self->{delta_ifInDiscards} / $totalInPkts;
+    my $totalOutPkts = $self->{delta_ifOutPkts} + $self->{delta_ifOutErrors} + $self->{delta_ifOutDiscards};
+    $self->{outputDiscardsPercent} = $totalOutPkts == 0 ? 0 :
+        100 * $self->{delta_ifOutDiscards} / $totalOutPkts;
     $self->{inputDiscardRate} = $self->{delta_ifInDiscards} 
         / $self->{delta_timestamp};
     $self->{outputDiscardRate} = $self->{delta_ifOutDiscards} 


### PR DESCRIPTION
## Problem Description

My customer encountered this issue on several firewall switches with WAN interfaces where the plugin reported error values exceeding 4000%. This mathematical impossibility indicated a bug in the percentage calculation logic.

## Root Cause Analysis

The current calculation uses only successful packets as the denominator:

`100 * $self->{delta_ifInErrors} / $self->{delta_ifInPkts}`

However, according to RFC 2863, the `ifInPkts`/`ifOutPkts` counters represent **only successfully received packets**, excluding errored/discarded packets. This means:
- Total packets on the wire = Successful packets + Error packets  
- Current formula: `Errors / Successful_packets * 100`
- Correct formula: `Errors / (Successful_packets + Errors) * 100`

*Note: This analysis was assisted by AI and should be verified against the full RFC specification.*

## Solution

This PR corrects the mathematical formula for both error and discard percentage calculations by including the errors/discards in the denominator.

## Related Issue

This fix addresses issue #307 opened by @andytlc68, who independently identified the same problem and proposed an identical solution. The issue already has community support with additional users confirming the problem, indicating this affects at least 3+ users in different environments.

## Testing

- ✅ Successfully tested in customer environment
- ✅ Error rates > 100% eliminated  
- ✅ Mathematical results now bounded to 0-100% range

## Disclaimer and Considerations

⚠️ **Please review carefully before merging:**

This fix modifies a core component of the plugin. While I've implemented this to the best of my knowledge and successfully tested it in our customer environment, I cannot provide absolute guarantee of correctness due to several considerations:

1. **Potential Side Effects**: This change affects core interface calculations and may have implications for other parts of the plugin that weren't immediately apparent.

2. **Scope Limitation**: I've only been able to verify this issue with error rates, but applied the same fix to discard calculations based on logical consistency.

3. **Calculation Precision**: The new calculation may still have edge cases or imprecision issues (e.g., lack of distinction between unicast/broadcast/multicast traffic).

4. **Vendor Implementation**: It's possible that only certain vendors incorrectly implement the SNMP specification, and this change might affect others differently.

**Recommendation**: Please conduct thorough testing across different network equipment vendors and gather community feedback before merging this PR.

Fixes #307