### PR TITLE
fix precedence problem in Cisco License check

### DIFF
--- a/plugins-scripts/CheckNwcHealth/Cisco/CISCOLICENSEMGMTMIB/Component/KeySubsystem.pm
+++ b/plugins-scripts/CheckNwcHealth/Cisco/CISCOLICENSEMGMTMIB/Component/KeySubsystem.pm
@@ -12,7 +12,7 @@ sub init {
 
 sub check {
   my ($self) = @_;
-  if (! $self->{licenses} eq "false") {
+  if (! ($self->{licenses} eq "false")) {
     $self->add_ok("licensing is not enabled");
   } else {
     $self->SUPER::check();


### PR DESCRIPTION
The latest perl version 5.42.0 complains about a possible misusage of the negation precedence. You can reproduce it on arch with my build scripts published today: https://aur.archlinux.org/packages/check-nwc-health-git

```
/usr/lib/monitoring-plugins/check_nwc_health 
Possible precedence problem between ! and string eq at /usr/lib/monitoring-plugins/check_nwc_health line 169188.
Usage: check_nwc_health [ -v|--verbose ] [ -t <timeout> ] --mode <what-to-do> --hostname <network-component> --community <snmp-community>  ...]
```

This PR removes this warning, but please make sure that this is the right intention to first evaluate `$self->{licenses} eq "false"`, than negate the result.

