### PR TITLE
Added `--deviceclass` option

### DIFF
--- a/plugins-scripts/CheckNwcHealth/Device.pm
+++ b/plugins-scripts/CheckNwcHealth/Device.pm
@@ -2,6 +2,36 @@ package CheckNwcHealth::Device;
 our @ISA = qw(Monitoring::GLPlugin::SNMP Monitoring::GLPlugin::UPNP);
 use strict;
 
+sub apply_device_class_override {
+  my ($self) = @_;
+  my $raw = $self->opts->deviceclass;
+  return if ! defined $raw || $raw eq '';
+  $raw =~ s/^\s+|\s+\z//g;
+  return if $raw eq '';
+  my $pkg = $raw;
+  unless ($pkg =~ /^(CheckNwcHealth|Server)(::[A-Za-z_][A-Za-z0-9_]*)+$/) {
+    $self->add_unknown("invalid deviceclass. Must start with CheckNwcHealth:: or Server::");
+    return;
+  }
+  (my $file = $pkg) =~ s{::}{/}g;
+  $file .= '.pm';
+  {
+    no strict 'refs';
+    my $stash = \%{$pkg . '::'};
+    if (! keys %{$stash}) {
+      eval { require $file; 1 } or do {
+        $self->add_unknown(sprintf "failed to load %s: %s", $pkg, $@ || 'unknown error');
+        return;
+      };
+    }
+  }
+  unless ($pkg->isa('CheckNwcHealth::Device')) {
+    $self->add_unknown(sprintf "%s is not a CheckNwcHealth::Device subclass", $pkg);
+    return;
+  }
+  $self->rebless($pkg);
+}
+
 sub classify {
   my ($self) = @_;
   if (! ($self->opts->hostname || $self->opts->snmpwalk)) {

--- a/plugins-scripts/check_nwc_health.pl
+++ b/plugins-scripts/check_nwc_health.pl
@@ -731,10 +731,19 @@ sub run_plugin {
    Select a specific hardware subsystem (Cisco UCS only)",
       required => 0,
       default => undef,
-  );  
-  
+  );
+  $plugin->add_arg(
+      spec => 'deviceclass=s',
+      help => "--deviceclass
+   Use this package as the device class override (e.g. CheckNwcHealth::Cisco::NXOS).
+   Skips autodetection. For local modes use e.g. Server::LinuxLocal.",
+      required => 0,
+      default => undef,
+  );
+
   $plugin->getopts();
   $plugin->classify();
+  $plugin->apply_device_class_override();
   $plugin->validate_args();
   
   if (! $plugin->check_messages()) {


### PR DESCRIPTION
Recently, I switched from version 10.3 to the latest version of this script and noticed that Cisco Firepower devices are now detected differently than before. In earlier versions, they were treated as Cisco ASA devices. Now they are recognized as Firepower devices and therefore use the Firepower OIDs in this script.

Unfortunately, this new behavior changes how some checks function. For example, the `cpu-load` mode now reports actual load values instead of percentages.

Even more concerning, some checks are no longer implemented in the newer version, such as `connection-count`.

Because of this, I needed a way to force the use of ASA MIBs for my Firepower targets. This pull request provides that solution. I added the `--deviceclass` option, which allows the script to be executed with, e.g., `--deviceclass 'CheckNwcHealth::Cisco::ASA'` to enforce the use of the ASA class.