### PR TITLE
Set sysobjectid to empty if does not exist

### DIFF
--- a/plugins-scripts/CheckNwcHealth/Cisco.pm
+++ b/plugins-scripts/CheckNwcHealth/Cisco.pm
@@ -4,7 +4,7 @@ use strict;
 
 sub init {
   my ($self) = @_;
-  my $sysobjectid = $self->get_snmp_object('MIB-2-MIB', 'sysObjectID', 0);
+  my $sysobjectid = $self->get_snmp_object('MIB-2-MIB', 'sysObjectID', 0) // '';
   $sysobjectid =~ s/^\.//g;
   if ($self->{productname} =~ /Cisco NX-OS/i) {
     $self->rebless('CheckNwcHealth::Cisco::NXOS');


### PR DESCRIPTION
This fixes #370 by setting $sysobjectid to an empty string if the snmp query did not obtain anything.